### PR TITLE
Base DB2 Dialect Functionality

### DIFF
--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -10,6 +10,8 @@ The JDBC adapter currently supports the following SQL dialects and data sources.
 * Oracle
 * Teradata
 * Redshift
+* [DB2](doc/db2-dialect.md)
+
 
 Each such implementation of a dialect handles three major aspects:
 * How to **map the tables** in the source systems to virtual tables in EXASOL, including how to **map the data types** to EXASOL data types.

--- a/jdbc-adapter/doc/db2-dialect.md
+++ b/jdbc-adapter/doc/db2-dialect.md
@@ -1,0 +1,18 @@
+# DB2 Dialect
+Short description of DB2 Dialect functionality and features
+
+## Casting of Data Types
+* TIMESTAMP and TIMESTAMP(x) will be cast to VARCHAR to not lose precision.
+* VARCHAR and CHAR for bit data will be cast to a hex string with double the original size
+* TIME will be cast to VARCHAR(8)
+* XML will be cast to VARCHAR(DB2_MAX_LENGTH)
+* BLOB is not supported
+
+## Casting of Functions
+* LIMIT will replaced by FETCH FIRST x ROWS ONLY
+* OFFESET currently not supported as only DB2 V11 support this
+* ADD_DAYS, ADD_WEEKS ... will be replaced by COLUMN + DAYS, COLUMN + ....
+
+## Unit Tests 
+Unit Test setup how to has been included with various tests.
+See [setup sql file](../integration-test-data/db2-testdata.sql) for details

--- a/jdbc-adapter/integration-test-data/db2-testdata.sql
+++ b/jdbc-adapter/integration-test-data/db2-testdata.sql
@@ -1,0 +1,43 @@
+-- !!!! Attention SAMPLE Database will be dropped in the process
+-- create SAMPLE Database with sample data and tables; drop if exists
+-- before execution  db2 command window on windows or in any shell on unix set these environment variables:
+-- DB2CODEPAGE=1208
+-- in windows execute: chcp 65001
+-- then execute 
+-- db2 -svtf db2-testdata.sql
+
+--force create database sample
+--!db2sampl -force -verbose;
+connect to sample;
+
+--create additional table for bit data, large timestamp and unicode tests
+update command options using s off;
+drop table ADDITIONAL_DATATYPES ;
+update command options using s on;
+create table ADDITIONAL_DATATYPES 
+(
+	BIDATAVARCHAR VARCHAR(1024) FOR BIT DATA
+	,BIDATACHAR CHAR(100) FOR BIT DATA
+	,UNICODECOL VARCHAR(1024) 
+	,DETAIL_TIMESTAMP TIMESTAMP(12)
+	,UHRZEIT TIME
+);
+INSERT INTO ADDITIONAL_DATATYPES  VALUES ('0001','AABB','CHAR 茶', '2020-01-01-00.00.00.123456789123','12.05.11');
+
+
+
+
+-- create alias for having the sample schema for the table -> normally sample tables are created in the schema db2userid
+
+ --time, unicode, detail timestamp, mixed case table and bit data columns test
+create alias db2test."Additional_Datatypes" for ADDITIONAL_DATATYPES;
+
+--clob test
+create alias db2test.emp_resume for emp_resume; 
+
+--xml and decimal test
+create alias db2test.product for product; 
+
+
+commit;
+connect reset;

--- a/jdbc-adapter/integration-test-data/integration-test-db2.yaml
+++ b/jdbc-adapter/integration-test-data/integration-test-db2.yaml
@@ -1,0 +1,29 @@
+# Configuration file for integration tests
+
+general:
+  debug:           false
+  debugAddress:    '192.168.0.12:3000'  # Address which will be defined as DEBUG_ADDRESS in the virtual schemas
+  bucketFsUrl:  http://exasol-host:2580/bucket1
+  bucketFsPassword: bucket1
+  jdbcAdapterPath:  /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-0.0.1-SNAPSHOT.jar
+
+exasol:
+  runIntegrationTests: true
+  address:  exasol-host:8563
+  user:     sys
+  password: exasol
+
+
+  
+db2:
+  runIntegrationTests: false
+  connectionString:    jdbc:db2://db2-host:50000/SAMPLE
+  jdbcDriverPath:      /buckets/mybucketfs/mybucket/DB2_Driver/
+  jdbcDriverJars:
+    - db2jcc4.jar
+    - db2jcc_license_cu.jar
+  user: db2inst1
+  password: password
+
+
+

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialects.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialects.java
@@ -43,7 +43,9 @@ public class SqlDialects {
             return new TeradataSqlDialect(context);
         } else if (name.equalsIgnoreCase(RedshiftSqlDialect.NAME)) {
             return new RedshiftSqlDialect(context);
-        } 
+	    } else if (name.equalsIgnoreCase(DB2SqlDialect.NAME)) {
+	        return new DB2SqlDialect(context);
+	    } 
         else {
             return null;
         }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
@@ -1,0 +1,406 @@
+package com.exasol.adapter.dialects.impl;
+
+import com.exasol.adapter.dialects.AbstractSqlDialect;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import com.exasol.adapter.capabilities.AggregateFunctionCapability;
+import com.exasol.adapter.capabilities.Capabilities;
+import com.exasol.adapter.capabilities.LiteralCapability;
+import com.exasol.adapter.capabilities.MainCapability;
+import com.exasol.adapter.capabilities.PredicateCapability;
+import com.exasol.adapter.capabilities.ScalarFunctionCapability;
+import com.exasol.adapter.dialects.SqlDialectContext;
+import com.exasol.adapter.dialects.SqlGenerationContext;
+import com.exasol.adapter.dialects.SqlGenerationVisitor;
+import com.exasol.adapter.metadata.DataType;
+
+/**
+ * Dialect for DB2 using the DB2 Connector jdbc driver.
+ *
+ * @author Karl Griesser (fullref@gmail.com)
+ */
+
+public class DB2SqlDialect extends AbstractSqlDialect {
+
+	public DB2SqlDialect(SqlDialectContext context)
+	{
+		super(context);
+	}
+
+	public static final String NAME = "DB2";
+	
+	@Override
+	public String getPublicName()
+	{
+		return NAME;
+	}
+
+	@Override
+	public Capabilities getCapabilities()
+	{
+		Capabilities cap = new Capabilities();
+        // Capabilities
+        cap.supportMainCapability(MainCapability.SELECTLIST_PROJECTION);
+        cap.supportMainCapability(MainCapability.SELECTLIST_EXPRESSIONS);
+        cap.supportMainCapability(MainCapability.FILTER_EXPRESSIONS);
+        cap.supportMainCapability(MainCapability.AGGREGATE_SINGLE_GROUP);
+        cap.supportMainCapability(MainCapability.AGGREGATE_GROUP_BY_COLUMN);
+        cap.supportMainCapability(MainCapability.AGGREGATE_GROUP_BY_EXPRESSION);
+        cap.supportMainCapability(MainCapability.AGGREGATE_GROUP_BY_TUPLE);
+        cap.supportMainCapability(MainCapability.AGGREGATE_HAVING);
+        cap.supportMainCapability(MainCapability.ORDER_BY_COLUMN);
+        cap.supportMainCapability(MainCapability.ORDER_BY_EXPRESSION);
+        cap.supportMainCapability(MainCapability.LIMIT);
+
+        // Predicates
+        cap.supportPredicate(PredicateCapability.AND);
+        cap.supportPredicate(PredicateCapability.OR);
+        cap.supportPredicate(PredicateCapability.NOT);
+        cap.supportPredicate(PredicateCapability.EQUAL);
+        cap.supportPredicate(PredicateCapability.NOTEQUAL);
+        cap.supportPredicate(PredicateCapability.LESS);
+        cap.supportPredicate(PredicateCapability.LESSEQUAL);
+        cap.supportPredicate(PredicateCapability.LIKE);
+        cap.supportPredicate(PredicateCapability.LIKE_ESCAPE);
+        // not supported cap.supportPredicate(PredicateCapability.REGEXP_LIKE);
+        cap.supportPredicate(PredicateCapability.BETWEEN);
+        cap.supportPredicate(PredicateCapability.IN_CONSTLIST);
+        cap.supportPredicate(PredicateCapability.IS_NULL);
+        cap.supportPredicate(PredicateCapability.IS_NOT_NULL);
+
+        // Literals
+        // BOOL is not supported
+        cap.supportLiteral(LiteralCapability.NULL);
+        cap.supportLiteral(LiteralCapability.DATE);
+        cap.supportLiteral(LiteralCapability.TIMESTAMP);
+        cap.supportLiteral(LiteralCapability.TIMESTAMP_UTC);
+        cap.supportLiteral(LiteralCapability.DOUBLE);
+        cap.supportLiteral(LiteralCapability.EXACTNUMERIC);
+        cap.supportLiteral(LiteralCapability.STRING);
+        cap.supportLiteral(LiteralCapability.INTERVAL);
+
+        // Aggregate functions
+        cap.supportAggregateFunction(AggregateFunctionCapability.COUNT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.COUNT_STAR);
+        cap.supportAggregateFunction(AggregateFunctionCapability.COUNT_DISTINCT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.GROUP_CONCAT);
+        // GROUP_CONCAT_DISTINCT is supported
+        cap.supportAggregateFunction(AggregateFunctionCapability.GROUP_CONCAT_SEPARATOR);
+        cap.supportAggregateFunction(AggregateFunctionCapability.GROUP_CONCAT_ORDER_BY);
+        // GEO_INTERSECTION_AGGREGATE is not supported
+        // GEO_UNION_AGGREGATE is not supported
+        // APPROXIMATE_COUNT_DISTINCT supported with version >= 12.1.0.2
+        // Cast result to FLOAT because result set precision = 0, scale = 0
+        cap.supportAggregateFunction(AggregateFunctionCapability.SUM);
+        cap.supportAggregateFunction(AggregateFunctionCapability.SUM_DISTINCT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.MIN);
+        cap.supportAggregateFunction(AggregateFunctionCapability.MAX);
+        cap.supportAggregateFunction(AggregateFunctionCapability.AVG);
+        cap.supportAggregateFunction(AggregateFunctionCapability.AVG_DISTINCT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.MEDIAN);
+        cap.supportAggregateFunction(AggregateFunctionCapability.FIRST_VALUE);
+        cap.supportAggregateFunction(AggregateFunctionCapability.LAST_VALUE);
+        cap.supportAggregateFunction(AggregateFunctionCapability.STDDEV);
+        // not supported  cap.supportAggregateFunction(AggregateFunctionCapability.STDDEV_DISTINCT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.STDDEV_POP);
+        // STDDEV_POP_DISTINCT
+        cap.supportAggregateFunction(AggregateFunctionCapability.STDDEV_SAMP);
+        // STDDEV_SAMP_DISTINCT
+        cap.supportAggregateFunction(AggregateFunctionCapability.VARIANCE);
+        cap.supportAggregateFunction(AggregateFunctionCapability.VARIANCE_DISTINCT);
+        cap.supportAggregateFunction(AggregateFunctionCapability.VAR_POP);
+        // VAR_POP_DISTINCT
+        cap.supportAggregateFunction(AggregateFunctionCapability.VAR_SAMP);
+        // VAR_SAMP_DISTINCT
+
+        // Scalar functions
+        cap.supportScalarFunction(ScalarFunctionCapability.CEIL);
+        cap.supportScalarFunction(ScalarFunctionCapability.DIV);
+        cap.supportScalarFunction(ScalarFunctionCapability.FLOOR);
+        cap.supportScalarFunction(ScalarFunctionCapability.SIGN);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD);
+        cap.supportScalarFunction(ScalarFunctionCapability.SUB);
+        cap.supportScalarFunction(ScalarFunctionCapability.MULT);
+        cap.supportScalarFunction(ScalarFunctionCapability.FLOAT_DIV);
+        cap.supportScalarFunction(ScalarFunctionCapability.NEG);
+        cap.supportScalarFunction(ScalarFunctionCapability.ABS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ACOS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ASIN);
+        cap.supportScalarFunction(ScalarFunctionCapability.ATAN);
+        cap.supportScalarFunction(ScalarFunctionCapability.ATAN2);
+        cap.supportScalarFunction(ScalarFunctionCapability.COS);
+        cap.supportScalarFunction(ScalarFunctionCapability.COSH);
+        cap.supportScalarFunction(ScalarFunctionCapability.COT);
+        cap.supportScalarFunction(ScalarFunctionCapability.DEGREES);
+        cap.supportScalarFunction(ScalarFunctionCapability.EXP);
+        cap.supportScalarFunction(ScalarFunctionCapability.GREATEST);
+        cap.supportScalarFunction(ScalarFunctionCapability.LEAST);
+        cap.supportScalarFunction(ScalarFunctionCapability.LN);
+        cap.supportScalarFunction(ScalarFunctionCapability.LOG);
+        cap.supportScalarFunction(ScalarFunctionCapability.MOD);
+        cap.supportScalarFunction(ScalarFunctionCapability.POWER);
+        cap.supportScalarFunction(ScalarFunctionCapability.RADIANS);
+        // RAND is not supported (constant arguments in EXA, will not be pushed down)
+        cap.supportScalarFunction(ScalarFunctionCapability.SIN);
+        cap.supportScalarFunction(ScalarFunctionCapability.SINH);
+        cap.supportScalarFunction(ScalarFunctionCapability.SQRT);
+        cap.supportScalarFunction(ScalarFunctionCapability.TAN);
+        cap.supportScalarFunction(ScalarFunctionCapability.TANH);
+        cap.supportScalarFunction(ScalarFunctionCapability.ASCII);
+        // BIT_LENGTH is not supported. Can be different for Unicode characters.
+        cap.supportScalarFunction(ScalarFunctionCapability.CHR);
+        // COLOGNE_PHONETIC is not supported.
+
+        // CONCAT is not supported. Number of arguments can be different.
+        // DUMP is not supported. Output is different.
+        // EDIT_DISTANCE is not supported. Output is different. UTL_MATCH.EDIT_DISTANCE returns -1 with NULL argument.
+        // INSERT is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.INSTR);
+        cap.supportScalarFunction(ScalarFunctionCapability.LENGTH);
+        cap.supportScalarFunction(ScalarFunctionCapability.LOCATE);
+        cap.supportScalarFunction(ScalarFunctionCapability.LOWER);
+        cap.supportScalarFunction(ScalarFunctionCapability.LPAD);
+        cap.supportScalarFunction(ScalarFunctionCapability.LTRIM);
+        // OCTET_LENGTH is not supported. Can be different for Unicode characters.
+        // not supported cap.supportScalarFunction(ScalarFunctionCapability.REGEXP_INSTR);
+     // not supported cap.supportScalarFunction(ScalarFunctionCapability.REGEXP_REPLACE);
+     // not supported cap.supportScalarFunction(ScalarFunctionCapability.REGEXP_SUBSTR);
+        cap.supportScalarFunction(ScalarFunctionCapability.REPEAT);
+        cap.supportScalarFunction(ScalarFunctionCapability.REPLACE);
+        // REVERSE is not supported
+        cap.supportScalarFunction(ScalarFunctionCapability.RIGHT);
+        cap.supportScalarFunction(ScalarFunctionCapability.RPAD);
+        cap.supportScalarFunction(ScalarFunctionCapability.RTRIM);
+        cap.supportScalarFunction(ScalarFunctionCapability.SOUNDEX);
+        cap.supportScalarFunction(ScalarFunctionCapability.RPAD);
+        cap.supportScalarFunction(ScalarFunctionCapability.SUBSTR);
+        cap.supportScalarFunction(ScalarFunctionCapability.TRANSLATE);
+        cap.supportScalarFunction(ScalarFunctionCapability.TRIM);
+        // UNICODE is not supported.
+        // UNICODECHR is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.UPPER);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_DAYS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_HOURS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_MINUTES);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_MONTHS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_SECONDS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_WEEKS);
+        cap.supportScalarFunction(ScalarFunctionCapability.ADD_YEARS);
+        // CONVERT_TZ is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.CURRENT_DATE);
+        cap.supportScalarFunction(ScalarFunctionCapability.CURRENT_TIMESTAMP);
+        // DATE_TRUNC is not supported. Format options for TRUNCATE are different.
+        // DAY is not supported. EXTRACT does not work on strings.
+        // DAYS_BETWEEN is not supported. EXTRACT does not work on strings.
+        // not supported cap.supportScalarFunction(ScalarFunctionCapability.DBTIMEZONE);
+        // EXTRACT is not supported. SECOND must be cast to DOUBLE.
+        // HOURS_BETWEEN is not supported. EXTRACT does not work on strings.
+        cap.supportScalarFunction(ScalarFunctionCapability.LOCALTIMESTAMP);
+        // MINUTE is not supported. EXTRACT does not work on strings.
+        // MINUTES_BETWEEN is not supported. EXTRACT does not work on strings.
+        // MONTH is not supported. EXTRACT does not work on strings.
+        // MONTHS_BETWEEN is not supported. EXTRACT does not work on strings.
+        //cap.supportScalarFunction(ScalarFunctionCapability.NUMTODSINTERVAL);
+        //cap.supportScalarFunction(ScalarFunctionCapability.NUMTOYMINTERVAL);
+        // POSIX_TIME is not supported. Does not work on strings.
+        // SECOND is not supported. EXTRACT does not work on strings.
+        // SECONDS_BETWEEN is not supported. EXTRACT does not work on strings.
+        // SESSIONTIMEZONE is not supported
+        cap.supportScalarFunction(ScalarFunctionCapability.SYSDATE);
+        cap.supportScalarFunction(ScalarFunctionCapability.SYSTIMESTAMP);
+        // WEEK is not supported.
+        // YEAR is not supported. EXTRACT does not work on strings.
+        // YEARS_BETWEEN is not supported. EXTRACT does not work on strings.
+        // ST_X is not supported.
+        // ST_Y is not supported.
+        // ST_ENDPOINT is not supported.
+        // ST_ISCLOSED is not supported.
+        // ST_ISRING is not supported.
+        // ST_LENGTH is not supported.
+        // ST_NUMPOINTS is not supported.
+        // ST_POINTN is not supported.
+        // ST_STARTPOINT is not supported.
+        // ST_AREA is not supported.
+        // ST_EXTERIORRING is not supported.
+        // ST_INTERIORRINGN is not supported.
+        // ST_NUMINTERIORRINGS is not supported.
+        // ST_GEOMETRYN is not supported.
+        // ST_NUMGEOMETRIES is not supported.
+        // ST_BOUNDARY is not supported.
+        // ST_BUFFER is not supported.
+        // ST_CENTROID is not supported.
+        // ST_CONTAINS is not supported.
+        // ST_CONVEXHULL is not supported.
+        // ST_CROSSES is not supported.
+        // ST_DIFFERENCE is not supported.
+        // ST_DIMENSION is not supported.
+        // ST_DISJOINT is not supported.
+        // ST_DISTANCE is not supported.
+        // ST_ENVELOPE is not supported.
+        // ST_EQUALS is not supported.
+        // ST_FORCE2D is not supported.
+        // ST_GEOMETRYTYPE is not supported.
+        // ST_INTERSECTION is not supported.
+        // ST_INTERSECTS is not supported.
+        // ST_ISEMPTY is not supported.
+        // ST_ISSIMPLE is not supported.
+        // ST_OVERLAPS is not supported.
+        // ST_SETSRID is not supported.
+        // ST_SYMDIFFERENCE is not supported.
+        // ST_TOUCHES is not supported.
+        // ST_TRANSFORM is not supported.
+        // ST_UNION is not supported.
+        // ST_WITHIN is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.CAST);
+        // IS_NUMBER is not supported.
+        // IS_BOOLEAN is not supported.
+        // IS_DATE is not supported.
+        // IS_DSINTERVAL is not supported.
+        // IS_YMINTERVAL is not supported.
+        // IS_TIMESTAMP is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.TO_CHAR);
+        cap.supportScalarFunction(ScalarFunctionCapability.TO_DATE);
+        cap.supportScalarFunction(ScalarFunctionCapability.TO_NUMBER);
+        cap.supportScalarFunction(ScalarFunctionCapability.TO_TIMESTAMP);
+        // BIT_CHECK is not supported.
+        // BIT_NOT is not supported.
+        // BIT_OR is not supported.
+        // BIT_SET is not supported.
+        // BIT_XOR is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.CASE);
+        cap.supportScalarFunction(ScalarFunctionCapability.CURRENT_SCHEMA);
+        cap.supportScalarFunction(ScalarFunctionCapability.CURRENT_USER);
+        cap.supportScalarFunction(ScalarFunctionCapability.NULLIFZERO);
+        // SYS_GUID is not supported.
+        cap.supportScalarFunction(ScalarFunctionCapability.ZEROIFNULL);
+
+        return cap;
+	}
+
+	@Override
+	public SchemaOrCatalogSupport supportsJdbcCatalogs()
+	{
+		return SchemaOrCatalogSupport.UNSUPPORTED;
+	}
+
+	@Override
+	public SchemaOrCatalogSupport supportsJdbcSchemas()
+	{
+		return SchemaOrCatalogSupport.SUPPORTED;
+	}
+
+	@Override
+	public IdentifierCaseHandling getUnquotedIdentifierHandling()
+	{
+		return IdentifierCaseHandling.INTERPRET_AS_UPPER;
+	}
+
+	@Override
+	public IdentifierCaseHandling getQuotedIdentifierHandling()
+	{
+		return IdentifierCaseHandling.INTERPRET_CASE_SENSITIVE;
+	}
+
+	@Override
+	public String applyQuote(String identifier)
+	{
+        // If identifier contains double quotation marks ", it needs to be espaced by another double quotation mark. E.g. "a""b" is the identifier a"b in the db.
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
+	}
+
+	@Override
+	public String applyQuoteIfNeeded(String identifier)
+	{
+        // Quoted identifiers can contain any unicode char except dot (.).
+        // This is a simplified rule, which might cause that some identifiers are quoted although not needed
+        boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
+        if (isSimpleIdentifier) {
+            return identifier;
+        } else {
+            return applyQuote(identifier);
+        }
+	}
+
+	@Override
+	public boolean requiresCatalogQualifiedTableNames(
+			SqlGenerationContext context)
+	{
+		//DB2 does not know catalogs
+		return false;
+	}
+
+	@Override
+	public boolean requiresSchemaQualifiedTableNames(
+			SqlGenerationContext context)
+	{
+		return true;
+	}
+	
+	@Override
+	public SqlGenerationVisitor getSqlGenerationVisitor(SqlGenerationContext context) {
+		return new DB2SqlGenerationVisitor(this, context);
+	}
+
+	@Override
+	public NullSorting getDefaultNullSorting()
+	{
+		//default db2 behaviour is to set nulls to the end of the result
+		return NullSorting.NULLS_SORTED_AT_END;
+	}
+
+	@Override
+	public String getStringLiteral(String value)
+	{
+        // Don't forget to escape single quote
+        return "'" + value.replace("'", "''") + "'";
+	}
+	
+	@Override
+	public DataType mapJdbcType(ResultSet cols) throws SQLException {
+		DataType colType = null;
+		int jdbcType = cols.getInt("DATA_TYPE");
+		
+		switch (jdbcType) {
+		case Types.CLOB:
+			colType = DataType.createVarChar(DataType.maxExasolVarcharSize, DataType.ExaCharset.UTF8);
+			break;
+		case 1111:
+			colType = DataType.createVarChar(DataType.maxExasolVarcharSize, DataType.ExaCharset.UTF8);
+			break;
+		// set timestamp to varchar as db2 offers a much higher precision than exasol
+		// however java timestamp only supports nanoseconds -> varchar(32)
+		case Types.TIMESTAMP:
+			colType = DataType.createVarChar(32, DataType.ExaCharset.UTF8);
+			break;
+			
+		// db2 driver always delivers UTF8 Characters no matter what encoding is specified for var + char data
+        case Types.VARCHAR:
+        case Types.NVARCHAR:
+        case Types.LONGVARCHAR:
+        case Types.CHAR:
+        case Types.NCHAR:
+        case Types.LONGNVARCHAR: {
+            int size = cols.getInt("COLUMN_SIZE");
+            DataType.ExaCharset charset =  DataType.ExaCharset.UTF8;
+            if (size <= DataType.maxExasolVarcharSize) {
+                colType = DataType.createVarChar(size, charset);
+            } else {
+                colType = DataType.createVarChar(DataType.maxExasolVarcharSize, charset);
+            }
+            break;
+        }
+			
+		// VARCHAR  and CHAR for bit data -> will be converted to hex string so we have to double the size
+		case -2:
+			colType = DataType.createChar(cols.getInt("COLUMN_SIZE")*2, DataType.ExaCharset.ASCII);
+		case -3:
+			colType = DataType.createVarChar(cols.getInt("COLUMN_SIZE")*2, DataType.ExaCharset.ASCII);
+			break;
+		}
+		return colType;
+	}
+
+}

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlGenerationVisitor.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlGenerationVisitor.java
@@ -1,0 +1,406 @@
+package com.exasol.adapter.dialects.impl;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.exasol.adapter.dialects.SqlDialect;
+import com.exasol.adapter.dialects.SqlGenerationContext;
+import com.exasol.adapter.dialects.SqlGenerationVisitor;
+import com.exasol.adapter.jdbc.ColumnAdapterNotes;
+import com.exasol.adapter.metadata.ColumnMetadata;
+import com.exasol.adapter.sql.ScalarFunction;
+import com.exasol.adapter.sql.SqlColumn;
+import com.exasol.adapter.sql.SqlFunctionAggregate;
+import com.exasol.adapter.sql.SqlFunctionAggregateGroupConcat;
+import com.exasol.adapter.sql.SqlFunctionScalar;
+import com.exasol.adapter.sql.SqlLimit;
+import com.exasol.adapter.sql.SqlNode;
+import com.exasol.adapter.sql.SqlNodeType;
+import com.exasol.adapter.sql.SqlSelectList;
+import com.exasol.adapter.sql.SqlStatementSelect;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * @author Karl Griesser (fullref@gmail.com)
+ */
+
+
+public class DB2SqlGenerationVisitor extends SqlGenerationVisitor {
+
+    private Set<ScalarFunction> scalarFunctionsCast = new HashSet<>();
+
+	public DB2SqlGenerationVisitor(SqlDialect dialect, SqlGenerationContext context) {
+		super(dialect, context);
+		
+	}
+	
+    @Override
+    public String visit(SqlColumn column) {
+        return getColumnProjectionString(column, super.visit(column));
+    }
+
+    private String getColumnProjectionString(SqlColumn column, String projString) {
+        boolean isDirectlyInSelectList = (column.hasParent() && column.getParent().getType() == SqlNodeType.SELECT_LIST);
+        if (!isDirectlyInSelectList) {
+            return projString;
+        }
+       
+        String typeName = ColumnAdapterNotes.deserialize(column.getMetadata().getAdapterNotes(), column.getMetadata().getName()).getTypeName();
+        
+        return getColumnProjectionStringNoCheckImpl(typeName, column, projString);
+       
+    }
+
+    
+    private String getColumnProjectionStringNoCheck(SqlColumn column, String projString) {
+
+        String typeName = ColumnAdapterNotes.deserialize(column.getMetadata().getAdapterNotes(), column.getMetadata().getName()).getTypeName();
+        
+        return getColumnProjectionStringNoCheckImpl(typeName, column, projString);
+        
+    }
+    
+    
+    private String getColumnProjectionStringNoCheckImpl(String typeName, SqlColumn column, String projString) {
+    	
+    	switch (typeName) {
+		case "XML":
+            projString = "XMLSERIALIZE(" + projString + " as VARCHAR(32000) INCLUDING XMLDECLARATION)";
+			break;
+		//db2 does not support cast of clobs to varchar in full length  -> max 32672
+		case "CLOB":
+			projString = "CAST(SUBSTRING(" + projString + ",32672) AS VARCHAR(32672))";
+			break;
+		case "CHAR () FOR BIT DATA":
+		case "VARCHAR () FOR BIT DATA":
+			projString = "HEX(" + projString + ")";
+			break;
+		case "TIME":
+		// cast timestamp to not lose precision
+		case "TIMESTAMP":
+			projString = "VARCHAR("+ projString + ")";
+			break;
+		default:
+			break;
+		}
+    	
+        if (TYPE_NAME_NOT_SUPPORTED.contains(typeName)){
+        	
+        	projString = "'"+typeName+" NOT SUPPORTED'"; //returning a string constant for unsupported data types
+        	
+        }
+        	
+        return projString;
+    }
+	
+    @Override
+    public String visit(SqlStatementSelect select) {
+        if (!select.hasLimit()) {
+            return super.visit(select);
+        } else {
+        	SqlLimit limit = select.getLimit();
+        	
+            StringBuilder sql = new StringBuilder();
+            sql.append("SELECT ");
+            
+            sql.append(select.getSelectList().accept(this));
+            sql.append(" FROM ");
+            sql.append(select.getFromClause().accept(this));
+            if (select.hasFilter()) {
+                sql.append(" WHERE ");
+                sql.append(select.getWhereClause().accept(this));
+            }
+            if (select.hasGroupBy()) {
+                sql.append(" GROUP BY ");
+                sql.append(select.getGroupBy().accept(this));
+            }
+            if (select.hasHaving()) {
+                sql.append(" HAVING ");
+                sql.append(select.getHaving().accept(this));
+            }
+            if (select.hasOrderBy()) {
+                sql.append(" ");
+                sql.append(select.getOrderBy().accept(this));
+            }
+            sql.append(" FETCH FIRST " + limit.getLimit() + " ROWS ONLY");
+            return sql.toString();   
+        }
+    }
+
+	
+    @Override
+    public String visit(SqlSelectList selectList) {
+        if (selectList.isRequestAnyColumn()) {
+            // The system requested any column
+            return "1";
+        }
+        List<String> selectListElements = new ArrayList<>();
+        if (selectList.isSelectStar()) {
+            if (selectListRequiresCasts(selectList)) {
+
+                // Do as if the user has all columns in select list
+                SqlStatementSelect select = (SqlStatementSelect) selectList.getParent();
+                
+                int columnId = 0;
+                for (ColumnMetadata columnMeta : select.getFromClause().getMetadata().getColumns()) {
+                    SqlColumn sqlColumn = new SqlColumn(columnId, columnMeta);
+                    selectListElements.add( getColumnProjectionStringNoCheck(sqlColumn,  super.visit(sqlColumn)  )   );
+                    ++columnId;
+                }
+                
+            } else {
+                selectListElements.add("*");
+            }
+        } else {
+            for (SqlNode node : selectList.getExpressions()) {
+                selectListElements.add(node.accept(this));
+            }
+        }
+       
+        return Joiner.on(", ").join(selectListElements);
+    }
+	
+	@Override
+	public String visit(SqlFunctionScalar function) {
+        String sql = super.visit(function);
+		
+		switch (function.getFunction()) {
+        case TRIM: {
+            List<String> argumentsSql = new ArrayList<>();
+            for (SqlNode node : function.getArguments()) {
+                argumentsSql.add(node.accept(this));
+            }
+            StringBuilder builder = new StringBuilder();
+            builder.append("TRIM(");
+            if (argumentsSql.size() > 1) {
+                builder.append(argumentsSql.get(1));
+                builder.append(" FROM ");
+                builder.append(argumentsSql.get(0));
+            } else {
+                builder.append(argumentsSql.get(0));
+            }
+            builder.append(")");
+            sql = builder.toString();
+            break;
+        	}
+        case ADD_DAYS:
+        case ADD_HOURS:
+        case ADD_MINUTES:
+        case ADD_SECONDS:
+        case ADD_WEEKS:
+        case ADD_YEARS: {
+            List<String> argumentsSql = new ArrayList<>();
+            Boolean isTimestamp = false; //special cast required
+            
+            for (SqlNode node : function.getArguments()) {
+                argumentsSql.add(node.accept(this));
+            }
+            StringBuilder builder = new StringBuilder();
+            
+            SqlColumn column = (SqlColumn) function.getArguments().get(0);
+            String typeName = ColumnAdapterNotes.deserialize(column.getMetadata().getAdapterNotes(), column.getMetadata().getName()).getTypeName();
+            System.out.println("!DB2 : " + typeName);
+            if (typeName.contains("TIMESTAMP")) 
+			{
+            	isTimestamp = true;
+                System.out.println("!DB2 : we got a timestamp");
+            	builder.append("VARCHAR(");
+			}
+
+            builder.append(argumentsSql.get(0));
+            builder.append(" + ");
+            builder.append(argumentsSql.get(1));
+            builder.append(" ");
+            switch (function.getFunction()) {
+            case ADD_DAYS:
+            case ADD_WEEKS:
+                builder.append("DAYS");
+                break;
+            case ADD_HOURS:
+                builder.append("HOURS");
+                break;
+            case ADD_MINUTES:
+                builder.append("MINUTES");
+                break;
+            case ADD_SECONDS:
+                builder.append("SECONDS");
+                break;
+            case ADD_YEARS:
+                builder.append("YEARS");
+                break;
+            default:
+                break;
+            }
+            if (isTimestamp)
+            {
+            	builder.append(")");
+            }
+            sql = builder.toString();
+            break;
+        	}
+        case CURRENT_DATE:
+            sql = "CURRENT DATE";
+            break;
+        case CURRENT_TIMESTAMP:
+            sql = "VARCHAR(CURRENT TIMESTAMP)";
+            break;
+        case DBTIMEZONE:
+            sql = "DBTIMEZONE";
+            break;
+        case LOCALTIMESTAMP:
+            sql = "LOCALTIMESTAMP";
+            break;
+        case SESSIONTIMEZONE:
+            sql = "SESSIONTIMEZONE";
+            break;
+        case SYSDATE:
+            sql = "CURRENT DATE";
+            break;
+        case SYSTIMESTAMP:
+	            sql = "VARCHAR(CURRENT TIMESTAMP)";
+	            break;
+        case BIT_AND:
+	            sql = sql.replaceFirst("^BIT_AND", "BITAND");
+	            break;
+        case BIT_TO_NUM:
+	            sql = sql.replaceFirst("^BIT_TO_NUM", "BIN_TO_NUM");
+	            break;
+        case NULLIFZERO: {
+	            List<String> argumentsSql = new ArrayList<>();
+	            for (SqlNode node : function.getArguments()) {
+	                argumentsSql.add(node.accept(this));
+	            }
+	            StringBuilder builder = new StringBuilder();
+	            builder.append("NULLIF(");
+	            builder.append(argumentsSql.get(0));
+	            builder.append(", 0)");
+	            sql = builder.toString();
+	            break;
+	        }
+        case ZEROIFNULL: {
+	            List<String> argumentsSql = new ArrayList<>();
+	            for (SqlNode node : function.getArguments()) {
+	                argumentsSql.add(node.accept(this));
+	            }
+	            StringBuilder builder = new StringBuilder();
+	            builder.append("IFNULL(");
+	            builder.append(argumentsSql.get(0));
+	            builder.append(", 0)");
+	            sql = builder.toString();
+	            break;
+	        }
+        case DIV: {
+	            List<String> argumentsSql = new ArrayList<>();
+	            for (SqlNode node : function.getArguments()) {
+	                argumentsSql.add(node.accept(this));
+	            }
+	            StringBuilder builder = new StringBuilder();
+	            builder.append("CAST(FLOOR(");
+	            builder.append(argumentsSql.get(0));
+	            builder.append(" / FLOOR(");
+	            builder.append(argumentsSql.get(1));
+	            builder.append(")) AS DECIMAL(36, 0))");
+	            sql = builder.toString();
+	            break;
+	        }
+        default:
+            break;
+        }
+
+        boolean isDirectlyInSelectList = (function.hasParent() && function.getParent().getType() == SqlNodeType.SELECT_LIST);
+        if (isDirectlyInSelectList && scalarFunctionsCast.contains(function.getFunction())) {
+            // Cast to FLOAT because result set metadata has precision = 0, scale = 0
+            sql = "CAST("  + sql + " AS FLOAT)";
+        }
+
+        return sql;
+    }
+		
+	
+	@Override
+	public String visit(SqlFunctionAggregate function) {
+		String sql = super.visit(function);
+		
+		switch (function.getFunction()) {
+		case VAR_SAMP:
+			sql = sql.replaceFirst("^VAR_SAMP", "VARIANCE_SAMP");
+			break;
+		default:
+			break;
+		}
+		
+		return sql;
+	}
+	
+	
+    @Override
+    public String visit(SqlFunctionAggregateGroupConcat function) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("LISTAGG");
+        builder.append("(");
+        assert(function.getArguments() != null);
+        assert(function.getArguments().size() == 1 && function.getArguments().get(0) != null);
+        String expression = function.getArguments().get(0).accept(this);
+        builder.append(expression);
+        builder.append(", ");
+        String separator = ",";
+        if (function.getSeparator() != null) {
+            separator = function.getSeparator();
+        }
+        builder.append("'");
+        builder.append(separator);
+        builder.append("') ");
+        builder.append("WITHIN GROUP(ORDER BY ");
+        if (function.hasOrderBy()) {
+            for (int i = 0; i < function.getOrderBy().getExpressions().size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                builder.append(function.getOrderBy().getExpressions().get(i).accept(this));
+                if (!function.getOrderBy().isAscending().get(i)) {
+                    builder.append(" DESC");
+                }
+            }
+        } else {
+            builder.append(expression);
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+
+    
+    private static final List<String> TYPE_NAMES_REQUIRING_CAST = ImmutableList.of("TIMESTAMP","DECFLOAT","CLOB","XML","TIME");
+    private static final List<String>  TYPE_NAME_NOT_SUPPORTED =  ImmutableList.of("BLOB"); 
+
+
+    private boolean nodeRequiresCast(SqlNode node) {
+        if (node.getType() == SqlNodeType.COLUMN) {
+            SqlColumn column = (SqlColumn)node;
+            String typeName = ColumnAdapterNotes.deserialize(column.getMetadata().getAdapterNotes(), column.getMetadata().getName()).getTypeName();
+            return TYPE_NAMES_REQUIRING_CAST.contains(typeName);
+        }
+        return false;
+    }
+
+    private boolean selectListRequiresCasts(SqlSelectList selectList) {
+        boolean requiresCasts = false;
+
+        // Do as if the user has all columns in select list
+        SqlStatementSelect select = (SqlStatementSelect) selectList.getParent();
+        int columnId = 0;
+        for (ColumnMetadata columnMeta : select.getFromClause().getMetadata().getColumns()) {
+        	
+        	
+        	if (nodeRequiresCast(new SqlColumn(columnId, columnMeta))) {
+                requiresCasts = true;
+        	}
+        }
+
+        return requiresCasts;
+    }
+
+
+}

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -30,7 +30,8 @@ public class JdbcAdapter {
                         OracleSqlDialect.NAME,
                         TeradataSqlDialect.NAME,
                         RedshiftSqlDialect.NAME,
-                        HiveSqlDialect.NAME));
+                        HiveSqlDialect.NAME,
+                        DB2SqlDialect.NAME));
     }
 
     /**

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/IntegrationTestConfig.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/IntegrationTestConfig.java
@@ -138,7 +138,7 @@ public class IntegrationTestConfig {
     public String getTeradataJdbcConnectionString() {
         return getProperty("teradata", "connectionString");
     }
-
+    
     public String getTeradataUser() {
         return getProperty("teradata", "user");
     }
@@ -158,6 +158,32 @@ public class IntegrationTestConfig {
     public boolean teradataTestsRequested() {
         return getProperty("teradata", "runIntegrationTests", false);
     }
+
+    
+    public String getDB2JdbcConnectionString() {
+    	return getProperty("db2", "connectionString");
+    }
+
+    public String getDB2User() {
+        return getProperty("db2", "user");
+    }
+
+    public String getDB2Password() {
+        return getProperty("db2", "password");
+    }
+
+    public String getDB2JdbcPrefixPath() {
+        return getProperty("db2", "jdbcDriverPath");
+    }
+
+    public List<String> getDB2JdbcJars() {
+        return getProperty("db2", "jdbcDriverJars");
+    }
+    
+    public boolean DB2TestsRequested() {
+        return getProperty("db2", "runIntegrationTests", false);
+    }
+    
     
     public boolean genericTestsRequested() {
         return getProperty("generic", "runIntegrationTests", false);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
@@ -1,0 +1,135 @@
+package com.exasol.adapter.dialects.impl;
+
+import com.exasol.adapter.dialects.AbstractIntegrationTest;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Integration test for theDB2 SQL dialect
+ *
+ */
+public class DB2SqlDialectIT extends AbstractIntegrationTest {
+
+
+	private static final String VIRTUAL_SCHEMA = "DB2";
+    private static final String DB2_SCHEMA = "DB2TEST";
+    private static final boolean IS_LOCAL = false;
+    
+   
+    @BeforeClass
+    public static void setUpClass() throws FileNotFoundException, SQLException, ClassNotFoundException {
+        Assume.assumeTrue(getConfig().DB2TestsRequested());
+        setConnection(connectToExa());
+
+        createDB2JDBCAdapter();
+        createVirtualSchema(
+                VIRTUAL_SCHEMA,
+               DB2SqlDialect.NAME,
+                "", DB2_SCHEMA,
+                "",
+                getConfig().getDB2User(),
+                getConfig().getDB2Password(),
+                "ADAPTER.JDBC_ADAPTER",
+                getConfig().getDB2JdbcConnectionString(),
+                IS_LOCAL,
+                getConfig().debugAddress(),
+                "");
+    }
+    
+ 
+    @Test
+    public void testSelectNumericDataTypes() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT PRICE,PROMOPRICE FROM " + VIRTUAL_SCHEMA + ".PRODUCT WHERE pid = '100-100-01'";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		new BigDecimal("9.99"),
+        		new BigDecimal("7.25") 
+        		);
+        matchSingleRowExplain(query, "SELECT PRICE, PROMOPRICE FROM " + DB2_SCHEMA + ".PRODUCT WHERE PID = '100-100-01'");
+    }
+    
+    @Test 
+    public void testLimit() throws SQLException, ClassNotFoundException,FileNotFoundException {
+        String query = "SELECT * FROM (SELECT price,PROMOPRICE FROM DB2.PRODUCT) AS A LIMIT 1 ";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		new BigDecimal("9.99"),
+        		new BigDecimal("7.25") 
+        		);
+        matchSingleRowExplain(query, "SELECT PRICE, PROMOPRICE FROM " + DB2_SCHEMA + ".PRODUCT FETCH FIRST 1 ROWS ONLY");
+    }
+    
+    @Test
+    public void testTimeDataTypeConversions() throws SQLException, ClassNotFoundException,FileNotFoundException {
+        String query = "SELECT DETAIL_TIMESTAMP,UHRZEIT FROM " + VIRTUAL_SCHEMA + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		"2020-01-01-00.00.00.123456789123",
+        		"12.05.11" 
+        		);
+        matchSingleRowExplain(query, "SELECT VARCHAR(DETAIL_TIMESTAMP), VARCHAR(UHRZEIT) FROM " + DB2_SCHEMA + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+    	
+    }
+    
+    @Test
+    public void testBitDataConversion() throws SQLException, ClassNotFoundException,FileNotFoundException {
+        String query = "SELECT BIDATAVARCHAR,BIDATACHAR FROM " + VIRTUAL_SCHEMA + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		"30303031", 
+        		"41414242202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020" 
+        		);
+        matchSingleRowExplain(query, "SELECT HEX(BIDATAVARCHAR), HEX(BIDATACHAR) FROM "+ DB2_SCHEMA + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+    	
+    }
+    
+    @Test
+    public void testUnicode() throws SQLException, ClassNotFoundException,FileNotFoundException {
+        String query = "SELECT UNICODECOL FROM " + VIRTUAL_SCHEMA + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		"CHAR 茶"
+        		);
+        matchSingleRowExplain(query, "SELECT UNICODECOL FROM " + DB2_SCHEMA + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+    	
+    }
+    
+    
+    @Test
+    public void testScalarFunctions() throws SQLException, ClassNotFoundException,FileNotFoundException {
+        String query = "SELECT ADD_DAYS(DETAIL_TIMESTAMP,2),ADD_YEARS(DETAIL_TIMESTAMP,-2),SUBSTR(UNICODECOL,1,4) FROM " + VIRTUAL_SCHEMA + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
+        ResultSet result = executeQuery(query);
+        matchNextRow(
+        		result,
+        		"2020-01-03-00.00.00.123456789123",
+        		"2018-01-01-00.00.00.123456789123",
+        		"CHAR"
+        		);
+        matchSingleRowExplain(query, "SELECT VARCHAR(DETAIL_TIMESTAMP + 2 DAYS), VARCHAR(DETAIL_TIMESTAMP + -2 YEARS), SUBSTR(UNICODECOL, 1, 4) FROM " + DB2_SCHEMA + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+    }
+    
+    private static void createDB2JDBCAdapter() throws SQLException, FileNotFoundException {
+        List<String>DB2Includes = new ArrayList<>();
+       DB2Includes.add(getConfig().getJdbcAdapterPath());
+        String jdbcPrefixPath = getConfig().getDB2JdbcPrefixPath();
+        for (String jar : getConfig().getDB2JdbcJars()) {
+           DB2Includes.add(jdbcPrefixPath + jar);
+        }
+        createJDBCAdapter(DB2Includes);
+    }
+
+}


### PR DESCRIPTION
Hi,

I've written DB2Dialect support for Exasol and want to add it back to the Github repository.

Except from Generic JDBC this Dialect supports

* XML Cast to VARCHAR
* Cast for BINARY CHAR and VARCHAR to Hex Strings
* Mapping of ADD_* Functions to DB2 Syntax 
* Timestamp cast to VARCHAR to not lose precision

There is also a mapping for all Columns to be UTF8. The Exasol Generic driver would map every string to ASCII even though the DB2 driver always returns UTF8 Strings no matter was the original Codepage of DB2 database is.

I've also created working (at least for me) Unit tests that can be recreated with any (freely) available DB2 Edition.

DB2 for zOS (Mainframe ) should be working as well. 

Kind Regards

Charly


 

