### PR TITLE
Support for native import from Oracle (issue #26)

### DIFF
--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -146,7 +146,9 @@ You have to make sure that Exasol can connect to the host running the udf_debug.
 ## Frequent Issues
 * **Error: No suitable driver found for JDBC...**: The JDBC driver class was not discovered automatically. Either you have to add a META-INF/services/java.sql.Driver file with the classname to your jar, or you have to load the driver manually (see JdbcMetadataReader.readRemoteMetadata()).
 See https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html
-
+* **Very slow execution of queries with SCRIPT_OUTPUT_ADDRESS**: If `SCRIPT_OUTPUT_ADDRESS` is set as explained in the [debugging section](#debugging), verify that a service is actually listening at that address. Otherwise, if Exasol can not establish a connection, repeated connection attempts can be the cause for slowdowns.
+* **Very slow execution of queries**: Depending on which JDK version Exasol uses to execute Java user-defined functions, a blocking randomness source may be used by default. Especially cryptographic operations do not complete until the operating system has collected a sufficient amount of entropy. This problem seems to occur most often when Exasol is run in an isolated environment, e.g., a virtual machine or a container. A solution is to use a non-blocking randomness source. 
+  To do so, log in to EXAOperation and shutdown the database. Append `-etlJdbcJavaEnv -Djava.security.egd=/dev/./urandom` to the "Extra Database Parameters" input field and power the database on again.
 
 ## Developing New Dialects
 

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -90,16 +90,16 @@ DROP VIRTUAL SCHEMA hive CASCADE;
 ### Adapter Properties
 The following properties can be used to control the behavior of the JDBC adapter. As you see above, these properties can be defined in `CREATE VIRTUAL SCHEMA` or changed afterwards via `ALTER VIRTUAL SCHEMA SET`. Note that properties are always strings, like `TABLE_FILTER='T1,T2'`.
 
-**Mandatory Parameter:**
+**Mandatory Properties:**
 
-Parameter                   | Value
+Property                    | Value
 --------------------------- | -----------
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
 
 **Mandatory Connection Specification:**
 Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`,String `USERNAME` and `PASSWORD`.
 
-Parameter                   | Value
+Property                    | Value
 --------------------------- | -----------
 **CONNECTION_NAME**         | Name of the connection created with `CREATE CONNECTION` which contains the JDBC connection string, the username and password. If you defined this property then it is not allowed to set CONNECTION_STRING, USERNAME and PASSWORD. We recommend using this property to ensure that the password will not be shown in the logfiles.
 **CONNECTION_STRING**       | The JDBC connection string. Only required if CONNECTION_NAME is not set.
@@ -107,9 +107,9 @@ Parameter                   | Value
 **PASSWORD**                | Password for authentication. Only required if CONNECTION_NAME is not set.
 
 
-**Common Optional Parameters:**
+**Common Optional Properties:**
 
-Parameter                   | Value
+Property                    | Value
 --------------------------- | -----------
 **CATALOG_NAME**            | The name of the remote JDBC catalog. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of catalogs.
 **SCHEMA_NAME**             | The name of the remote JDBC schema. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of schemas.
@@ -117,7 +117,7 @@ Parameter                   | Value
 
 **Advanced Optional Properties:**
 
-Parameter                   | Value
+Property                    | Value
 --------------------------- | -----------
 **IMPORT_FROM_EXA**         | Only relevant if your data source is EXASOL. Either 'TRUE' or 'FALSE' (default). If true, IMPORT FROM EXA will be used for the pushdown instead of IMPORT FROM JDBC. You have to define EXA_CONNECTION_STRING if this property is true.
 **EXA_CONNECTION_STRING**   | The connection string used for IMPORT FROM EXA in the format 'hostname:port'.

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -97,7 +97,7 @@ Parameter                   | Value
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
 
 **Mandatory Connection Specification:**
-Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`, `USERNAME` and `PASSWORD`. 
+Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`,String `USERNAME` and `PASSWORD`. 
 
 Parameter                   | Value
 --------------------------- | -----------
@@ -121,8 +121,8 @@ Parameter                   | Value
 --------------------------- | -----------
 **IMPORT_FROM_EXA**         | Only relevant if your data source is EXASOL. Either 'TRUE' or 'FALSE' (default). If true, IMPORT FROM EXA will be used for the pushdown instead of IMPORT FROM JDBC. You have to define EXA_CONNECTION_STRING if this property is true.
 **EXA_CONNECTION_STRING**   | The connection string used for IMPORT FROM EXA in the format 'hostname:port'.
-**IMPORT_FROM_ORA**         | Similar to IMPORT_FROM_EXA but for an Oracle data source. If enabled, the more performant IMPORT FROM ORA operation will be used in place of IMPORT FROM JDBC. You also need to define ORA_CONNECTION_STRING if this property is set to 'TRUE'.
-**ORA_CONNECTION_STRING**   | The connection string (or "connect descripter") used for IMPORT FROM ORA in the format '(DESCRIPTION= [...])' as described [here](https://docs.oracle.com/cd/E11882_01/network.112/e41945/concepts.htm#NETAG253).
+**IMPORT_FROM_ORA**         | Similar to IMPORT_FROM_EXA but for an Oracle data source. If enabled, the more performant `IMPORT FROM ORA` operation will be used in place of `IMPORT FROM JDBC`. You also need to define ORA_CONNECTION_NAME if this property is set to 'TRUE'.
+**ORA_CONNECTION_NAME**     | Name of the connection to an Oracle database created with `CREATE CONNECTION`. Used by `IMPORT FROM ORA`.
 **IS_LOCAL**                | Only relevant if your data source is the same Exasol database where you create the virtual schema. Either 'TRUE' or 'FALSE' (default). If true, you are connecting to the local Exasol database (e.g. for testing purposes). In this case, the adapter can avoid the IMPORT FROM JDBC overhead.
 **EXCEPTION_HANDLING**      | Activates or deactivates different exception handling modes. Supported values: 'IGNORE_INVALID_VIEWS', 'NONE' (default). Currently this property only affects the Teradata dialect.
 

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -88,27 +88,32 @@ DROP VIRTUAL SCHEMA hive CASCADE;
 
 
 ### Adapter Properties
-The following properties can be used to control the behavior of the JDBC adapter. As you see above, these properties can be defined in ```CREATE VIRTUAL SCHEMA``` or changed afterwards via ```ALTER VIRTUAL SCHEMA SET```. Note that properties are always strings, like `TABLE_FILTER='T1,T2'`.
+The following properties can be used to control the behavior of the JDBC adapter. As you see above, these properties can be defined in `CREATE VIRTUAL SCHEMA` or changed afterwards via `ALTER VIRTUAL SCHEMA SET`. Note that properties are always strings, like `TABLE_FILTER='T1,T2'`.
 
-**Mandatory Properties:**
+**Mandatory Parameter:**
 
 Parameter                   | Value
 --------------------------- | -----------
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
-**CONNECTION_NAME**         | Name of the connection created with ```CREATE CONNECTION``` which contains the jdbc connection string, the username and password. If you defined this property then it is not allowed to set CONNECTION_STRING, USERNAME and PASSWORD. We recommend using this property to ensure that the password will not be shown in the logfiles.
-**CONNECTION_STRING**       | The jdbc connection string. Only required if CONNECTION_NAME is not set.
 
-
-**Typical Optional Parameters:**
+**Mandatory Connection Specification:**
+Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`, `USERNAME` and `PASSWORD`. 
 
 Parameter                   | Value
 --------------------------- | -----------
-**CATALOG_NAME**            | The name of the remote jdbc catalog. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of catalogs.
-**SCHEMA_NAME**             | The name of the remote jdbc schema. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of schemas.
-**USERNAME**                | Username for authentication. Can only be set if CONNECTION_NAME is not set.
-**PASSWORD**                | Password for authentication. Can only be set if CONNECTION_NAME is not set.
-**TABLE_FILTER**            | A comma-separated list of table names (case sensitive). Only these tables will be available as virtual tables, other tables are ignored. Use this if you don't want to have all remote tables in your virtual schema.
+**CONNECTION_NAME**         | Name of the connection created with `CREATE CONNECTION` which contains the JDBC connection string, the username and password. If you defined this property then it is not allowed to set CONNECTION_STRING, USERNAME and PASSWORD. We recommend using this property to ensure that the password will not be shown in the logfiles.
+**CONNECTION_STRING**       | The JDBC connection string. Only required if CONNECTION_NAME is not set.
+**USERNAME**                | Username for authentication. Only required if CONNECTION_NAME is not set.
+**PASSWORD**                | Password for authentication. Only required if CONNECTION_NAME is not set.
 
+
+**Common Optional Parameters:**
+
+Parameter                   | Value
+--------------------------- | -----------
+**CATALOG_NAME**            | The name of the remote JDBC catalog. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of catalogs.
+**SCHEMA_NAME**             | The name of the remote JDBC schema. This is usually case-sensitive, depending on the dialect. It depends on the dialect whether you have to specify this or not. Usually you have to specify it if the data source JDBC driver supports the concepts of schemas.
+**TABLE_FILTER**            | A comma-separated list of table names (case sensitive). Only these tables will be available as virtual tables, other tables are ignored. Use this if you don't want to have all remote tables in your virtual schema.
 
 **Advanced Optional Properties:**
 
@@ -116,6 +121,8 @@ Parameter                   | Value
 --------------------------- | -----------
 **IMPORT_FROM_EXA**         | Only relevant if your data source is EXASOL. Either 'TRUE' or 'FALSE' (default). If true, IMPORT FROM EXA will be used for the pushdown instead of IMPORT FROM JDBC. You have to define EXA_CONNECTION_STRING if this property is true.
 **EXA_CONNECTION_STRING**   | The connection string used for IMPORT FROM EXA in the format 'hostname:port'.
+**IMPORT_FROM_ORA**         | Similar to IMPORT_FROM_EXA but for an Oracle data source. If enabled, the more performant IMPORT FROM ORA operation will be used in place of IMPORT FROM JDBC. You also need to define ORA_CONNECTION_STRING if this property is set to 'TRUE'.
+**ORA_CONNECTION_STRING**   | The connection string (or "connect descripter") used for IMPORT FROM ORA in the format '(DESCRIPTION= [...])' as described [here](https://docs.oracle.com/cd/E11882_01/network.112/e41945/concepts.htm#NETAG253).
 **IS_LOCAL**                | Only relevant if your data source is the same Exasol database where you create the virtual schema. Either 'TRUE' or 'FALSE' (default). If true, you are connecting to the local Exasol database (e.g. for testing purposes). In this case, the adapter can avoid the IMPORT FROM JDBC overhead.
 **EXCEPTION_HANDLING**      | Activates or deactivates different exception handling modes. Supported values: 'IGNORE_INVALID_VIEWS', 'NONE' (default). Currently this property only affects the Teradata dialect.
 
@@ -137,7 +144,7 @@ You have to make sure that Exasol can connect to the host running the udf_debug.
 
 
 ## Frequent Issues
-* **Error: No suitable driver found for jdbc...**: The jdbc driver class was not discovered automatically. Either you have to add a META-INF/services/java.sql.Driver file with the classname to your jar, or you have to load the driver manually (see JdbcMetadataReader.readRemoteMetadata()).
+* **Error: No suitable driver found for JDBC...**: The JDBC driver class was not discovered automatically. Either you have to add a META-INF/services/java.sql.Driver file with the classname to your jar, or you have to load the driver manually (see JdbcMetadataReader.readRemoteMetadata()).
 See https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html
 
 

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -97,7 +97,7 @@ Parameter                   | Value
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
 
 **Mandatory Connection Specification:**
-Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`,String `USERNAME` and `PASSWORD`. 
+Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`,String `USERNAME` and `PASSWORD`.
 
 Parameter                   | Value
 --------------------------- | -----------

--- a/jdbc-adapter/doc/supported-dialects.md
+++ b/jdbc-adapter/doc/supported-dialects.md
@@ -2,7 +2,7 @@
 
 The purpose of this page is to provide detailed instructions for each of the supported dialects on how to get started. Typical questions are
 * Which **JDBC driver** is used, which files have to be uploaded and included when creating the adapter script.
-* How does the **CREATE VIRTUAL SCHEMA** statement look like, i.e. which parameters are required.
+* How does the **CREATE VIRTUAL SCHEMA** statement look like, i.e. which properties are required.
 * **Data source specific notes**, like authentication with Kerberos, supported capabilities or things to consider regarding the data type mapping.
 
 As an entry point we recommend to follow the [step-by-step deployment guide](deploy-adapter.md) which will link to this page whenever needed.
@@ -306,7 +306,7 @@ CREATE JAVA ADAPTER SCRIPT adapter.jdbc_oracle AS
 ```
 
 **JDBC Connection**:
-Next, create a JDBC connection to your Oracle database. Adjust the parameters to match your environment.
+Next, create a JDBC connection to your Oracle database. Adjust the properties to match your environment.
 ```sql
 CREATE CONNECTION jdbc_oracle
   TO 'jdbc:oracle:thin:@//<host>:<port>/<service_name>'

--- a/jdbc-adapter/doc/supported-dialects.md
+++ b/jdbc-adapter/doc/supported-dialects.md
@@ -274,6 +274,90 @@ create  virtual schema db2 using adapter.jdbc_adapter with
 A how to has been included in the [setup sql file](../integration-test-data/db2-testdata.sql)
 
 ## Oracle
+**Supported capabilities**:
+???
+
+### JDBC driver
+To setup a virtual schema that communicates with an Oracle database using JDBC, the JDBC driver, e.g., `ojdbc7-12.1.0.2.jar`, must first be installed in EXAoperation and deployed to BucketFS; see [this article](https://www.exasol.com/support/browse/SOL-179#WhichJDBCdriverforOracleshallIuse?) and [Deploying the Adapter Step By Step](deploy-adapter.md) for instructions.
+
+**Adapter script**:
+After uploading the adapter jar we are ready to create an Oracle adapter script. Adapt the following script as indicated.
+```sql
+CREATE SCHEMA adapter;
+CREATE JAVA ADAPTER SCRIPT adapter.jdbc_oracle AS
+  %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
+
+  // You need to replace `your-bucket-fs` and `your-bucket` to match the actual location
+  // of the adapter jar.
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.0.1-SNAPSHOT.jar;
+
+  // Add the oracle jdbc driver to the classpath
+  %jar /buckets/bucketfs1/bucket1/ojdbc7-12.1.0.2.jar
+/
+```
+
+**JDBC Connection**:
+Next, create a JDBC connection to your Oracle database. Adjust the parameters to match your environment.
+```sql
+CREATE CONNECTION jdbc_oracle
+  TO 'jdbc:oracle:thin:@//<host>:<port>/<service_name>'
+  USER '<user>'
+  IDENTIFIED BY '<password>';
+```
+
+A quick option to test the `JDBC_ORACLE` connection is to run an `IMPORT FROM JDBC` query. The connection works, if `42` is returned.
+```sql
+IMPORT FROM JDBC AT jdbc_oracle
+  STATEMENT 'SELECT 42 FROM DUAL';
+```
+
+**Virtual schema:**
+Having created both a JDBC adapter script and a JDBC oracle connection, we are ready to create a virtual schema. Insert the name of the schema that you want to expose in Exasol.
+```sql
+CREATE VIRTUAL SCHEMA virt_oracle USING adapter.jdbc_oracle WITH
+  SQL_DIALECT     = 'ORACLE'
+  CONNECTION_NAME = 'JDBC_ORACLE'
+  SCHEMA_NAME     = '<schema>';
+```
+
+### Use IMPORT FROM ORA instead of IMPORT FROM JDBC**
+Exasol provides the `IMPORT FROM ORA` command for loading data from Oracle. It is possible to create a virtual schema that uses `IMPORT FROM ORA` instead of JDBC to communicate with Oracle. Both options are indented to support the same features. `IMPORT FROM ORA` almost always offers better performance since it is implemented natively.
+
+This behaviour is toggled by the Boolean `IMPORT_FROM_ORA` variable. Note that a JDBC connection to Oracle is still required to fetch metadata. In addition, a "direct" connection to the Oracle database is needed.
+
+**Deploy the Oracle Instant Client**:
+To be able to communicate with Oracle, you first need to supply Exasol with the Oracle Instant Client, which can be obtained [directly from Oracle](http://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html). Open EXAoperation, visit Software -> "Upload Oracle Instant Client" and select the downloaded package. The latest version of Oracle Instant Client we tested is "instantclient-basic-linux.x64-12.1.0.2.0".
+
+**Create an Oracle Connection**:
+Having deployed the Oracle Instant Client, a connection to your Oracle database can be set up.
+```sql
+CREATE CONNECTION conn_oracle
+  TO '(DESCRIPTION =
+		(ADDRESS_LIST = (ADDRESS = (PROTOCOL = TCP)
+                                   (HOST = <host>)
+                                   (PORT = <port>)))
+		(CONNECT_DATA = (SERVER = DEDICATED)
+                        (SERVICE_NAME = <service_name>)))'
+	USER '<username>'
+	IDENTIFIED BY '<password>';
+```
+
+This connection can be tested using, e.g., the following SQL expression.
+```sql
+IMPORT FROM ORA at CONN_ORACLE
+  STATEMENT 'SELECT 42 FROM DUAL';
+```
+
+**Virtual schema**:
+Assuming you already setup the JDBC connection `JDBC_ORACLE` as shown in the previous section, you can continue with creating the virtual schema.
+```sql
+CREATE VIRTUAL SCHEMA virt_import_oracle USING adapter.jdbc_oracle WITH
+  SQL_DIALECT     = 'ORACLE'
+  CONNECTION_NAME = 'JDBC_ORACLE'
+  SCHEMA_NAME     = '<schema>'
+  IMPORT_FROM_ORA = 'true'
+  EXA_CONNECTION_NAME = 'CONN_ORACLE';
+```
 
 ## Teradata
 

--- a/jdbc-adapter/doc/supported-dialects.md
+++ b/jdbc-adapter/doc/supported-dialects.md
@@ -275,7 +275,16 @@ A how to has been included in the [setup sql file](../integration-test-data/db2-
 
 ## Oracle
 **Supported capabilities**:
-???
+The Oracle dialect does not support all capabilities. A complete list can be found in [OracleSqlDialect.getCapabilities()](../virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java).
+
+Oracle datatypes are mapped to their equivalents in Exasol. The following exceptions apply:
+- `NUMBER`, `NUMBER with precision > 36` and `LONG` are casted to `VARCHAR` to prevent a loss of precision.
+- `DATE` is casted to `TIMESTAMP`. This datatype is only supported for positive year values, i.e., years > 0001.
+- `TIMESTAMP WITH [LOCAL] TIME ZONE` is casted to `VARCHAR`. Exasol does not support timestamps with time zone information.
+- `INTERVAL` is casted to `VARCHAR`.
+- `CLOB`, `NCLOB` and `BLOB` are casted to `VARCHAR`.
+- `RAW` and `LONG RAW` are not supported.
+
 
 ### JDBC driver
 To setup a virtual schema that communicates with an Oracle database using JDBC, the JDBC driver, e.g., `ojdbc7-12.1.0.2.jar`, must first be installed in EXAoperation and deployed to BucketFS; see [this article](https://www.exasol.com/support/browse/SOL-179#WhichJDBCdriverforOracleshallIuse?) and [Deploying the Adapter Step By Step](deploy-adapter.md) for instructions.

--- a/jdbc-adapter/integration-test-data/oracle-testdata.sql
+++ b/jdbc-adapter/integration-test-data/oracle-testdata.sql
@@ -1,0 +1,93 @@
+-- ORACLE 12
+
+CREATE USER loader IDENTIFIED BY loader;
+
+GRANT CONNECT TO loader;
+GRANT CREATE SESSION TO loader;
+GRANT UNLIMITED TABLESPACE TO loader;
+
+DROP TABLE LOADER.TYPE_TEST;
+CREATE TABLE LOADER.TYPE_TEST (
+  c1 char(50),
+  c2 nchar(50),
+  c3 varchar2(50),
+  c4 nvarchar2(50),
+  c5 number,
+  c_number36 number(36),
+  c6 number(38),
+  c7 number(10,5),
+  c_binfloat binary_float,
+  c_bindouble binary_double,
+  c10 date,
+  c11 timestamp(3),
+  c12 timestamp,
+  c13 timestamp(9),
+  c14 timestamp with time zone,
+  c15 timestamp with local time zone,
+  c16 interval year to month,
+  c17 interval day to second,
+  c18 blob,
+  c19 clob,
+  c20 nclob,
+  --c21 rowid,
+  --c22 urowid,
+  c_float float,
+  c_float126 float(126),
+  c_long long
+);
+
+INSERT INTO LOADER.TYPE_TEST VALUES (
+  'aaaaaaaaaaaaaaaaaaaa',
+  'bbbbbbbbbbbbbbbbbbbb',
+  'cccccccccccccccccccc',
+  'dddddddddddddddddddd',
+  123456789012345678901234567890123456, --C5
+  123456789012345678901234567890123456, -- c_number36
+  12345678901234567890123456789012345678, --C6
+  12345.12345, -- C7
+  1234.1241723, -- C_BINFLOAT
+  1234987.120871234, -- C_BINDOUBLE
+  TO_DATE('2016-08-19', 'YYYY-MM-DD'), -- c10
+  TO_TIMESTAMP('2013-03-11 17:30:15.123', 'YYYY-MM-DD HH24:MI:SS.FF'), -- c11
+  TO_TIMESTAMP('2013-03-11 17:30:15.123456', 'YYYY-MM-DD HH24:MI:SS.FF'), -- c12
+  TO_TIMESTAMP('2013-03-11 17:30:15.123456789', 'YYYY-MM-DD HH24:MI:SS.FF'), -- c13
+  TO_TIMESTAMP_TZ('2016-08-19 11:28:05 -08:00', 'YYYY-MM-DD HH24:MI:SS TZH:TZM'), -- c14
+  TO_TIMESTAMP_TZ('2018-04-30 10:00:05 -08:00', 'YYYY-MM-DD HH24:MI:SS TZH:TZM'), -- c15
+  '54-2', -- c16
+  '1 11:12:10.123', -- c17
+  '0102030405060708090a0b0c0d0e0f', -- c18
+  '0987asdlfkjq2222qawsf;lkja09ed8q2w;43lkrjasdf09uqaw43lkjra0-98sf[iqjw4,mfas[dpiuj[qa09w44', -- c19
+  '0987asdlfkjq2222qawsf;lkja09ed8q2w;43lkrjasdf09uqaw43lkjra0-98sf[iqjw4,mfas[dpiuj[qa09w44', -- c20
+  12345.01982348239, -- c_float
+  12345678.01234567901234567890123456789, -- c_float126
+  'test long 123' -- long
+);
+
+INSERT INTO LOADER.TYPE_TEST (c3, c5, c7, c_binfloat, c17) VALUES (
+  -- C1
+  -- C2
+  'cccccccccccccccccccc', -- C3
+  -- C4
+  1234567890.123456789, -- C5
+  -- c_number36
+  -- C6
+  12355.12345, -- C7
+  123.12345687987654321, -- c_binfloat
+  -- c_bindouble
+  -- C10
+  -- C11
+  -- C12
+  -- C13
+  -- C14
+  -- C15
+  -- C16
+  '2 02:03:04.123456' -- C17
+  -- C18
+  -- C19
+  -- C20
+  -- -- C21
+  -- -- C22
+  -- c_float
+  -- c_float126
+  -- c_long
+);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -217,8 +217,8 @@ public class JdbcAdapter {
                     credentials,
                     pushdownQuery.replace("'", "''"));
         } else if (JdbcAdapterProperties.isImportFromOra(meta.getProperties())) {
-            sql = String.format("IMPORT FROM ORA AT '%s' %s STATEMENT '%s'",
-                    JdbcAdapterProperties.getOraConnectionString(meta.getProperties()),
+            sql = String.format("IMPORT FROM ORA AT %s %s STATEMENT '%s'",
+                    JdbcAdapterProperties.getOraConnectionName(meta.getProperties()),
                     credentials,
                     pushdownQuery.replace("'", "''"));
         } else {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -202,45 +202,46 @@ public class JdbcAdapter {
         SqlGenerationVisitor sqlGeneratorVisitor = dialect.getSqlGenerationVisitor(context);
         String pushdownQuery = request.getSelect().accept(sqlGeneratorVisitor);
 
-        boolean isLocal = JdbcAdapterProperties.isLocal(meta.getProperties());
-        String credentialsAndConn = "";
-        if (JdbcAdapterProperties.userSpecifiedConnection(meta.getProperties())) {
-            credentialsAndConn = "AT " + JdbcAdapterProperties.getConnectionName(meta.getProperties());
-        } else {
-            ExaConnectionInformation connection = JdbcAdapterProperties.getConnectionInformation(meta.getProperties(), exaMeta);
-            if (JdbcAdapterProperties.isImportFromExa(meta.getProperties())) {
-                credentialsAndConn = "AT '" + JdbcAdapterProperties.getExaConnectionString(meta.getProperties()) + "'";
-            } else if (JdbcAdapterProperties.isImportFromOra(meta.getProperties())) {
-                credentialsAndConn = "AT '" + JdbcAdapterProperties.getOraConnectionString(meta.getProperties()) + "'";
-            } else {
-                credentialsAndConn = "AT '" + connection.getAddress() + "'";
-            }
-            credentialsAndConn += " USER '" + connection.getUser() + "'";
-            credentialsAndConn += " IDENTIFIED BY '" + connection.getPassword() + "'";
+        ExaConnectionInformation connection = JdbcAdapterProperties.getConnectionInformation(meta.getProperties(), exaMeta);
+        String credentials = "";
+        if (connection.getUser() != null || connection.getPassword() != null) {
+            credentials = "USER '" + connection.getUser() + "' IDENTIFIED BY '" + connection.getPassword() + "'";
         }
-        String importSql;
 
-        if (isLocal) {
-            importSql = pushdownQuery;
-
+        String sql = "";
+        if (JdbcAdapterProperties.isLocal(meta.getProperties())) {
+            sql = pushdownQuery;
         } else if (JdbcAdapterProperties.isImportFromExa(meta.getProperties())) {
-            importSql =  "IMPORT FROM EXA " + credentialsAndConn
-                    + " STATEMENT '" + pushdownQuery.replace("'", "''") + "'";
+            sql = String.format("IMPORT FROM EXA AT '%s' %s STATEMENT '%s'",
+                    JdbcAdapterProperties.getExaConnectionString(meta.getProperties()),
+                    credentials,
+                    pushdownQuery.replace("'", "''"));
         } else if (JdbcAdapterProperties.isImportFromOra(meta.getProperties())) {
-            importSql =  "IMPORT FROM ORA " + credentialsAndConn
-                + " STATEMENT '" + pushdownQuery.replace("'", "''") + "'";
+            sql = String.format("IMPORT FROM ORA AT '%s' %s STATEMENT '%s'",
+                    JdbcAdapterProperties.getOraConnectionString(meta.getProperties()),
+                    credentials,
+                    pushdownQuery.replace("'", "''"));
         } else {
+            if (JdbcAdapterProperties.userSpecifiedConnection(meta.getProperties())) {
+                credentials = JdbcAdapterProperties.getConnectionName(meta.getProperties());
+            } else {
+                credentials = "'" + connection.getAddress() + "' " + credentials;
+            }
+
             String columnDescription = createColumnDescription(exaMeta, meta, pushdownQuery, dialect);
-                if (columnDescription == null) {
-                    importSql = "IMPORT" + " FROM JDBC " + credentialsAndConn
-                            + " STATEMENT '" + pushdownQuery.replace("'", "''") + "'";
-                } else {
-                    importSql = "IMPORT INTO " + columnDescription + " FROM JDBC " + credentialsAndConn
-                            + " STATEMENT '" + pushdownQuery.replace("'", "''") + "'";
-                }
+            if (columnDescription == null) {
+                sql = String.format("IMPORT FROM JDBC AT %s STATEMENT '%s'",
+                        credentials,
+                        pushdownQuery.replace("'", "''"));
+            } else {
+                sql = String.format("IMPORT INTO %s FROM JDBC AT %s STATEMENT '%s'",
+                        columnDescription,
+                        credentials,
+                        pushdownQuery.replace("'", "''"));
+            }
         }
         
-        return ResponseJsonSerializer.makePushdownResponse(importSql);
+        return ResponseJsonSerializer.makePushdownResponse(sql);
     }
 
     private static String createColumnDescription(ExaMetadata exaMeta,

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -203,12 +203,13 @@ public class JdbcAdapter {
         String pushdownQuery = request.getSelect().accept(sqlGeneratorVisitor);
 
         boolean isLocal = JdbcAdapterProperties.isLocal(meta.getProperties());
+        boolean importFromExa = JdbcAdapterProperties.isImportFromExa(meta.getProperties());
         String credentialsAndConn = "";
         if (JdbcAdapterProperties.userSpecifiedConnection(meta.getProperties())) {
             credentialsAndConn = "AT " + JdbcAdapterProperties.getConnectionName(meta.getProperties());
         } else {
             ExaConnectionInformation connection = JdbcAdapterProperties.getConnectionInformation(meta.getProperties(), exaMeta);
-            if (JdbcAdapterProperties.isImportFromExa(meta.getProperties())) {
+            if (importFromExa) {
                 credentialsAndConn = "AT '" + JdbcAdapterProperties.getExaConnectionString(meta.getProperties()) + "'";
             } else {
                 credentialsAndConn = "AT '" + connection.getAddress() + "'";
@@ -217,9 +218,10 @@ public class JdbcAdapter {
             credentialsAndConn += " IDENTIFIED BY '" + connection.getPassword() + "'";
         }
         String importSql;
-        boolean importFromExa = JdbcAdapterProperties.isImportFromExa(meta.getProperties());
+
         if (isLocal) {
             importSql = pushdownQuery;
+
         } else if (importFromExa) {
 
             importSql =  "IMPORT FROM EXA " + credentialsAndConn

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -30,6 +30,8 @@ public class JdbcAdapterProperties {
     static final String PROP_SQL_DIALECT = "SQL_DIALECT";
     static final String PROP_IMPORT_FROM_EXA = "IMPORT_FROM_EXA";
     static final String PROP_EXA_CONNECTION_STRING = "EXA_CONNECTION_STRING";
+    static final String PROP_IMPORT_FROM_ORA = "IMPORT_FROM_ORA";
+    static final String PROP_ORA_CONNECTION_STRING = "ORA_CONNECTION_STRING";
     static final String PROP_EXCLUDED_CAPABILITIES = "EXCLUDED_CAPABILITIES";
     static final String PROP_EXCEPTION_HANDLING = "EXCEPTION_HANDLING";
 
@@ -92,14 +94,21 @@ public class JdbcAdapterProperties {
         validatePropertyValues(properties);
         
         checkMandatoryProperties(properties, supportedDialects);
-        
-        if (isImportFromExa(properties)) {
-            if (getExaConnectionString(properties).isEmpty()) {
-                throw new InvalidPropertyException("You defined the property " + PROP_IMPORT_FROM_EXA + ", please also define " + PROP_EXA_CONNECTION_STRING);
+
+        checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_EXA, PROP_EXA_CONNECTION_STRING);
+        checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_ORA, PROP_ORA_CONNECTION_STRING);
+    }
+
+    private static void checkImportPropertyConsistency(Map<String, String> properties, String propImportFromX, String propConnectionString) throws InvalidPropertyException {
+        boolean isImport = getProperty(properties, propImportFromX, "").toUpperCase().equals("TRUE");
+        boolean connectionStringIsEmpty = getProperty(properties, PROP_EXA_CONNECTION_STRING, "").isEmpty();
+        if (isImport) {
+            if (connectionStringIsEmpty) {
+                throw new InvalidPropertyException("You defined the property " + propImportFromX + ", please also define " + propConnectionString);
             }
         } else {
-            if (!getExaConnectionString(properties).isEmpty()) {
-                throw new InvalidPropertyException("You defined the property " + PROP_EXA_CONNECTION_STRING + " without setting " + PROP_IMPORT_FROM_EXA + " to 'TRUE'. This is not allowed");
+            if (!connectionStringIsEmpty) {
+                throw new InvalidPropertyException("You defined the property " + propConnectionString + " without setting " + propImportFromX + " to 'TRUE'. This is not allowed");
             }
         }
     }
@@ -107,6 +116,7 @@ public class JdbcAdapterProperties {
     private static void validatePropertyValues(Map<String, String> properties) throws AdapterException {
         validateBooleanProperty(properties, PROP_IS_LOCAL);
         validateBooleanProperty(properties, PROP_IMPORT_FROM_EXA);
+        validateBooleanProperty(properties, PROP_IMPORT_FROM_ORA);
         if (properties.containsKey(PROP_DEBUG_ADDRESS)) {
             validateDebugOutputAddress(properties.get(PROP_DEBUG_ADDRESS));
         }
@@ -172,6 +182,18 @@ public class JdbcAdapterProperties {
         return getProperty(properties, PROP_IMPORT_FROM_EXA, "").toUpperCase().equals("TRUE");
     }
 
+    public static boolean isImportFromOra(Map<String, String> properties) {
+        return getProperty(properties, PROP_IMPORT_FROM_ORA, "").toUpperCase().equals("TRUE");
+    }
+
+    public static String getExaConnectionString(Map<String, String> properties) {
+        return getProperty(properties, PROP_EXA_CONNECTION_STRING, "");
+    }
+
+    public static String getOraConnectionString(Map<String, String> properties) {
+        return getProperty(properties, PROP_ORA_CONNECTION_STRING, "");
+    }
+
     public static List<String> getTableFilter(Map<String, String> properties) {
         String tableNames = getProperty(properties, PROP_TABLES, "");
         if (!tableNames.isEmpty()) {
@@ -208,10 +230,6 @@ public class JdbcAdapterProperties {
             throw new InvalidPropertyException("SQL Dialect not supported: " + dialectName + " - all dialects: " + supportedDialects.getDialectsString());
         }
         return dialect;
-    }
-
-    public static String getExaConnectionString(Map<String, String> properties) {
-        return getProperty(properties, PROP_EXA_CONNECTION_STRING, "");
     }
 
     public static ExceptionHandlingMode getExceptionHandlingMode(Map<String, String> properties) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -31,7 +31,7 @@ public class JdbcAdapterProperties {
     static final String PROP_IMPORT_FROM_EXA = "IMPORT_FROM_EXA";
     static final String PROP_EXA_CONNECTION_STRING = "EXA_CONNECTION_STRING";
     static final String PROP_IMPORT_FROM_ORA = "IMPORT_FROM_ORA";
-    static final String PROP_ORA_CONNECTION_STRING = "ORA_CONNECTION_STRING";
+    static final String PROP_ORA_CONNECTION_NAME = "ORA_CONNECTION_NAME";
     static final String PROP_EXCLUDED_CAPABILITIES = "EXCLUDED_CAPABILITIES";
     static final String PROP_EXCEPTION_HANDLING = "EXCEPTION_HANDLING";
 
@@ -96,19 +96,19 @@ public class JdbcAdapterProperties {
         checkMandatoryProperties(properties, supportedDialects);
 
         checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_EXA, PROP_EXA_CONNECTION_STRING);
-        checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_ORA, PROP_ORA_CONNECTION_STRING);
+        checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_ORA, PROP_ORA_CONNECTION_NAME);
     }
 
-    private static void checkImportPropertyConsistency(Map<String, String> properties, String propImportFromX, String propConnectionString) throws InvalidPropertyException {
+    private static void checkImportPropertyConsistency(Map<String, String> properties, String propImportFromX, String propConnection) throws InvalidPropertyException {
         boolean isImport = getProperty(properties, propImportFromX, "").toUpperCase().equals("TRUE");
-        boolean connectionStringIsEmpty = getProperty(properties, propConnectionString, "").isEmpty();
+        boolean connectionIsEmpty = getProperty(properties, propConnection, "").isEmpty();
         if (isImport) {
-            if (connectionStringIsEmpty) {
-                throw new InvalidPropertyException("You defined the property " + propImportFromX + ", please also define " + propConnectionString);
+            if (connectionIsEmpty) {
+                throw new InvalidPropertyException("You defined the property " + propImportFromX + ", please also define " + propConnection);
             }
         } else {
-            if (!connectionStringIsEmpty) {
-                throw new InvalidPropertyException("You defined the property " + propConnectionString + " without setting " + propImportFromX + " to 'TRUE'. This is not allowed");
+            if (!connectionIsEmpty) {
+                throw new InvalidPropertyException("You defined the property " + propConnection + " without setting " + propImportFromX + " to 'TRUE'. This is not allowed");
             }
         }
     }
@@ -190,8 +190,8 @@ public class JdbcAdapterProperties {
         return getProperty(properties, PROP_EXA_CONNECTION_STRING, "");
     }
 
-    public static String getOraConnectionString(Map<String, String> properties) {
-        return getProperty(properties, PROP_ORA_CONNECTION_STRING, "");
+    public static String getOraConnectionName(Map<String, String> properties) {
+        return getProperty(properties, PROP_ORA_CONNECTION_NAME, "");
     }
 
     public static List<String> getTableFilter(Map<String, String> properties) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -101,7 +101,7 @@ public class JdbcAdapterProperties {
 
     private static void checkImportPropertyConsistency(Map<String, String> properties, String propImportFromX, String propConnectionString) throws InvalidPropertyException {
         boolean isImport = getProperty(properties, propImportFromX, "").toUpperCase().equals("TRUE");
-        boolean connectionStringIsEmpty = getProperty(properties, PROP_EXA_CONNECTION_STRING, "").isEmpty();
+        boolean connectionStringIsEmpty = getProperty(properties, propConnectionString, "").isEmpty();
         if (isImport) {
             if (connectionStringIsEmpty) {
                 throw new InvalidPropertyException("You defined the property " + propImportFromX + ", please also define " + propConnectionString);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/AbstractIntegrationTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/AbstractIntegrationTest.java
@@ -60,13 +60,17 @@ public class AbstractIntegrationTest {
         return executeQuery(connection, query);
     }
 
+    public int executeUpdate(String query) throws SQLException {
+        checkConnection();
+        return connection.createStatement().executeUpdate(query);
+    }
     public static void createJDBCAdapter(Connection conn, List<String> jarIncludes) throws SQLException {
         Statement stmt = conn.createStatement();
         stmt.execute("CREATE SCHEMA IF NOT EXISTS ADAPTER");
         String sql = "CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS\n";
-        sql += "%scriptclass com.exasol.adapter.jdbc.JdbcAdapter;";
+        sql += "  %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;\n";
         for (String includePath : jarIncludes) {
-            sql += " %jar " + includePath + ";\n";
+            sql += "  %jar " + includePath + ";\n";
         }
         //sql += " %jvmoption -Xms64m -Xmx64m;";
         sql += "/";
@@ -225,7 +229,7 @@ public class AbstractIntegrationTest {
     public static void matchSingleRowExplain(String query, String expectedExplain) throws SQLException {
         checkConnection();
         matchSingleRowExplain(connection, query, expectedExplain);
-    }
+   }
 
     private static List<Object> rowToObject(ResultSet resultSet) throws SQLException {
         int colCount = resultSet.getMetaData().getColumnCount();

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/AbstractIntegrationTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/AbstractIntegrationTest.java
@@ -78,7 +78,7 @@ public class AbstractIntegrationTest {
         createJDBCAdapter(connection, jarIncludes);
     }
 
-    public static void createVirtualSchema(Connection conn, String virtualSchemaName, String dialect, String remoteCatalog, String remoteSchema, String connectionName, String user, String password, String adapter, String remoteConnectionString, boolean isLocal, String debugAddress, String tableFilter) throws SQLException {
+    public static void createVirtualSchema(Connection conn, String virtualSchemaName, String dialect, String remoteCatalog, String remoteSchema, String connectionName, String user, String password, String adapter, String remoteConnectionString, boolean isLocal, String debugAddress, String tableFilter, String suffix) throws SQLException {
         removeVirtualSchema(conn, virtualSchemaName);
         String sql = "CREATE VIRTUAL SCHEMA " + virtualSchemaName;
         sql += " USING " + adapter;
@@ -112,12 +112,15 @@ public class AbstractIntegrationTest {
         if (!tableFilter.isEmpty()) {
             sql += " TABLE_FILTER='" + tableFilter + "'";
         }
+        if (suffix != null) {
+            sql += " " + suffix;
+        }
         conn.createStatement().execute(sql);
     }
 
-    public static void createVirtualSchema(String virtualSchemaName, String dialect, String remoteCatalog, String remoteSchema, String connectionName, String user, String password, String adapter, String remoteConnectionString, boolean isLocal, String debugAddress, String tableFilter) throws SQLException {
+    public static void createVirtualSchema(String virtualSchemaName, String dialect, String remoteCatalog, String remoteSchema, String connectionName, String user, String password, String adapter, String remoteConnectionString, boolean isLocal, String debugAddress, String tableFilter, String suffix) throws SQLException {
         checkConnection();
-        createVirtualSchema(connection, virtualSchemaName, dialect, remoteCatalog, remoteSchema, connectionName, user, password, adapter, remoteConnectionString, isLocal, debugAddress, tableFilter);
+        createVirtualSchema(connection, virtualSchemaName, dialect, remoteCatalog, remoteSchema, connectionName, user, password, adapter, remoteConnectionString, isLocal, debugAddress, tableFilter, suffix);
     }
 
     public static void createConnection(Connection conn, String connectionName, String connectionString, String user, String password) throws SQLException {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
@@ -42,7 +42,7 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
                 getConfig().getDB2JdbcConnectionString(),
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "");
+                "",null);
     }
     
  

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -54,7 +54,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
                 "ADAPTER.JDBC_ADAPTER",
                 connectionString, IS_LOCAL,
                 getConfig().debugAddress(),
-                "");
+                "", null);
         createVirtualSchema(
                 VIRTUAL_SCHEMA_MIXED_CASE,
                 ExasolSqlDialect.NAME,
@@ -65,7 +65,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
                 "ADAPTER.JDBC_ADAPTER",
                 connectionString, IS_LOCAL,
                 getConfig().debugAddress(),
-                "");
+                "",null);
     }
 
     private static void createTestSchema() throws SQLException {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/GenericSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/GenericSqlDialectIT.java
@@ -38,7 +38,7 @@ public class GenericSqlDialectIT extends AbstractIntegrationTest {
                 connectionString,
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "");
+                "", null);
     }
 
     @Test

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/HiveSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/HiveSqlDialectIT.java
@@ -41,7 +41,7 @@ public class HiveSqlDialectIT extends AbstractIntegrationTest {
                 getConfig().getHiveJdbcConnectionString(),
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "ALL_HIVE_DATA_TYPES");
+                "ALL_HIVE_DATA_TYPES",null);
     }
 
     @Test

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ImpalaSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ImpalaSqlDialectIT.java
@@ -41,7 +41,7 @@ public class ImpalaSqlDialectIT extends AbstractIntegrationTest {
                 getConfig().getImpalaJdbcConnectionString(),
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "SAMPLE_07,ALL_HIVE_IMPALA_TYPES,SIMPLE,SIMPLE_WITH_NULLS");
+                "SAMPLE_07,ALL_HIVE_IMPALA_TYPES,SIMPLE,SIMPLE_WITH_NULLS",null);
     }
 
     @Test

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/KerberosIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/KerberosIT.java
@@ -49,7 +49,7 @@ public class KerberosIT extends AbstractIntegrationTest {
                 "ADAPTER.JDBC_ADAPTER",
                 "", IS_LOCAL,
                 getConfig().debugAddress(),
-                "");
+                "", null);
         Statement stmt = getConnection().createStatement();
         ResultSet result = stmt.executeQuery("SELECT * FROM \"sample_07\"");
         result.next();
@@ -85,7 +85,7 @@ public class KerberosIT extends AbstractIntegrationTest {
                 adapterName,
                 "", false,
                 getConfig().debugAddress(),
-                "");
+                "", null);
         ResultSet result = stmt2.executeQuery("SELECT * FROM \"sample_07\"");
         result.next();
         assertEquals("00-0000", result.getString(1));

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
@@ -2,17 +2,26 @@ package com.exasol.adapter.dialects.impl;
 
 import com.exasol.adapter.dialects.AbstractIntegrationTest;
 import org.junit.Assume;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import javax.print.DocFlavor;
 import java.io.FileNotFoundException;
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.time.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /**
  * Tested with Oracle 12
@@ -22,139 +31,58 @@ import static org.junit.Assert.assertEquals;
  */
 public class OracleSqlDialectIT extends AbstractIntegrationTest {
 
-    private static final String VIRTUAL_SCHEMA = "VS_ORACLE";
-    private static final String ORACLE_SCHEMA = "C##LOADER";
+    private static final String VIRTUAL_SCHEMA_JDBC = "VS_ORACLE_JDBC";
+    private static final String VIRTUAL_SCHEMA_IMPORT = "VS_ORACLE_IMPORT";
+    private static final String ORACLE_SCHEMA = "LOADER";
+    private static final String TEST_TABLE = "TYPE_TEST";
+
+    private static final String EXA_TABLE_JDBC = VIRTUAL_SCHEMA_JDBC + "." + TEST_TABLE;
+    private static final String EXA_TABLE_IMPORT = VIRTUAL_SCHEMA_IMPORT + "." + TEST_TABLE;
+    private static final String ORA_TABLE = ORACLE_SCHEMA + "." + TEST_TABLE;
+
     private static final boolean IS_LOCAL = false;
 
-    @Before
-    public void beforeMethod() throws FileNotFoundException, SQLException, ClassNotFoundException {
+    // Use getColumnTypes() to access this map
+    private Map<String, String> columnTypes;
+
+    @BeforeClass
+    public static void beforeMethod() throws FileNotFoundException, SQLException, ClassNotFoundException {
         Assume.assumeTrue(getConfig().oracleTestsRequested());
         setConnection(connectToExa());
-        createOracleJDBCAdapter();
+        // createOracleJDBCAdapter();
+        createOracleConnection();
+        // create JDBC virtual schema
         createVirtualSchema(
-                VIRTUAL_SCHEMA,
+                VIRTUAL_SCHEMA_JDBC,
                 OracleSqlDialect.NAME,
-                "", ORACLE_SCHEMA,
                 "",
-                "C##LOADER",
-                "loader",
-                "ADAPTER.JDBC_ADAPTER",
+                ORACLE_SCHEMA,
+                "",
+                getConfig().getOracleUser(),
+                getConfig().getOraclePassword(),
+                //"ADAPTER.JDBC_ORACLE_DEBUG",
+                "ADAPTER.JDBC_ORACLE",
                 getConfig().getOracleJdbcConnectionString(),
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "ALL_TYPES",
-                null);
-    }
+                TEST_TABLE,null);
 
-    @Test
-    public void testVirtualSchema() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        ResultSet result = executeQuery("SELECT C3 FROM ALL_TYPES");
-        result.next();
-        assertEquals("cccccccccccccccccccc", result.getString(1));
-    }
-
-    @Test
-    public void testSelectProjection() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM ALL_TYPES";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, new BigDecimal("12345.12345"));
-        matchNextRow(result, new BigDecimal("12355.12345"));
-        matchSingleRowExplain(query, "SELECT C7 FROM \"C##LOADER\".ALL_TYPES");
-    }
-
-    @Test
-    public void testSelectExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 + 1 FROM ALL_TYPES";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12346.12345");
-        matchNextRow(result, "12356.12345");
-        matchSingleRowExplain(query, "SELECT CAST((C7 + 1) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES");
-    }
-
-    @Test
-    public void testFilterExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM ALL_TYPES WHERE C7 > 12346";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, new BigDecimal("12355.12345"));
-        matchSingleRowExplain(query, "SELECT C7 FROM \"C##LOADER\".ALL_TYPES WHERE 12346 < C7");
-    }
-
-    @Test
-    public void testAggregateSingleGroup() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT min(C7) FROM ALL_TYPES";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12345.12345");
-        matchSingleRowExplain(query, "SELECT CAST(MIN(C7) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES");
-    }
-
-    @Test
-    public void testAggregateGroupByColumn() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C5, min(C7) FROM ALL_TYPES GROUP BY C5";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12345678901234567890", "12345.12345");
-        matchNextRow(result, "1234567890.123456789", "12355.12345");
-        matchSingleRowExplain(query, "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES GROUP BY C5");
-    }
-
-    @Test
-    public void testAggregateGroupByExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C5 + 1, min(C7) FROM ALL_TYPES GROUP BY C5 + 1";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12345678901234567891", "12345.12345");
-        matchNextRow(result, "1234567891.123456789", "12355.12345");
-        matchSingleRowExplain(query, "SELECT CAST((C5 + 1) AS FLOAT), CAST(MIN(C7) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES GROUP BY (C5 + 1)");
-    }
-
-    @Test
-    public void testAggregateGroupByTuple() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C3, C5, min(C7) FROM ALL_TYPES GROUP BY C3, C5 ORDER BY C5 DESC";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "cccccccccccccccccccc", "12345678901234567890", "12345.12345");
-        matchNextRow(result, "cccccccccccccccccccc", "1234567890.123456789", "12355.12345");
-        matchSingleRowExplain(query, "SELECT C3, TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES GROUP BY C3, C5 ORDER BY C5 DESC");
-    }
-
-    @Test
-    public void testAggregateHaving() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C5, min(C7) FROM ALL_TYPES GROUP BY C5 HAVING MIN(C7) > 12350";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "1234567890.123456789", "12355.12345");
-        matchSingleRowExplain(query, "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM \"C##LOADER\".ALL_TYPES GROUP BY C5 HAVING 12350 < MIN(C7)");
-    }
-
-    @Test
-    public void testOrderByColumn() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C1 FROM ALL_TYPES ORDER BY C1 DESC NULLS LAST";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "aaaaaaaaaaaaaaaaaaaa                              ");
-        matchNextRow(result, (Object)null);
-        matchSingleRowExplain(query, "SELECT C1 FROM \"C##LOADER\".ALL_TYPES ORDER BY C1 DESC NULLS LAST");
-    }
-
-    @Test
-    public void testOrderByExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM ALL_TYPES ORDER BY ABS(C7) DESC NULLS FIRST";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, new BigDecimal("12355.12345"));
-        matchNextRow(result, new BigDecimal("12345.12345"));
-        matchSingleRowExplain(query, "SELECT C7 FROM \"C##LOADER\".ALL_TYPES ORDER BY ABS(C7) DESC");
-    }
-
-    @Test
-    public void testLimit() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM ALL_TYPES ORDER BY C7 LIMIT 2";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, new BigDecimal("12345.12345"));
-        matchNextRow(result, new BigDecimal("12355.12345"));
-        matchSingleRowExplain(query, "SELECT LIMIT_SUBSELECT.* FROM ( SELECT C7 FROM \"C##LOADER\".ALL_TYPES ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2");
-    }
-
-    @Test
-    public void testLimitOffset() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM ALL_TYPES ORDER BY C7 LIMIT 1 OFFSET 1";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, new BigDecimal("12355.12345"));
-        matchSingleRowExplain(query, "SELECT c0 FROM ( SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( SELECT C7 AS c0 FROM \"C##LOADER\".ALL_TYPES ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2 ) WHERE ROWNUM_SUB > 1");
+        // create IMPORT FROM ORA virtual schema
+        createVirtualSchema(
+                VIRTUAL_SCHEMA_IMPORT,
+                OracleSqlDialect.NAME,
+                "",
+                ORACLE_SCHEMA,
+                "",
+                getConfig().getOracleUser(),
+                getConfig().getOraclePassword(),
+                //"ADAPTER.JDBC_ORACLE_DEBUG",
+                "ADAPTER.JDBC_ORACLE",
+                getConfig().getOracleJdbcConnectionString(),
+                IS_LOCAL,
+                getConfig().debugAddress(),
+                TEST_TABLE,
+                "IMPORT_FROM_ORA='true' ORA_CONNECTION_NAME='CONN_ORACLE'");
     }
 
     private static void createOracleJDBCAdapter() throws SQLException, FileNotFoundException {
@@ -166,4 +94,395 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         createJDBCAdapter(includes);
     }
 
+    private String getColumnType(String column) throws SQLException {
+        if (columnTypes == null) {
+            columnTypes = getColumnTypesOfTable(EXA_TABLE_JDBC);
+        }
+        return columnTypes.get(column.toUpperCase());
+    }
+
+    private Map<String, String> getColumnTypesOfTable(String table) throws SQLException {
+        Map<String, String> map = new HashMap<>();
+        ResultSet result = executeQuery("DESCRIBE " + table);
+        while (result.next()) {
+            map.put(result.getString("COLUMN_NAME").toUpperCase(), result.getString("SQL_TYPE").toUpperCase());
+        }
+        return map;
+    }
+
+    // TODO: make configurable
+    private static void createOracleConnection() throws SQLException {
+        createConnection("CONN_ORACLE",
+                "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST = 10.44.1.186)(PORT = 1521)))(CONNECT_DATA = (SERVICE_NAME = xe)))",
+                "system", "oracle");
+    }
+
+    private List<ResultSet> runQuery(String query) throws SQLException {
+        ArrayList<ResultSet> result = new ArrayList<>();
+        result.add(executeQuery(String.format(query, EXA_TABLE_JDBC)));
+        result.add(executeQuery(String.format(query, EXA_TABLE_IMPORT)));
+        return result;
+    }
+
+    private void runMatchSingleRowExplain(String query, String expectedExplain) throws SQLException {
+        matchSingleRowExplain(String.format(query, EXA_TABLE_JDBC), expectedExplain);
+        matchSingleRowExplain(String.format(query, EXA_TABLE_IMPORT), expectedExplain);
+    }
+
+    private void matchNextRowDecimal(ResultSet result, String... expectedStrings) throws SQLException {
+        result.next();
+        if (result.getMetaData().getColumnCount() != expectedStrings.length) {
+            throw new IllegalArgumentException(String.format("Row has %d columns but only %d arguments were given",
+                    result.getMetaData().getColumnCount(), expectedStrings.length));
+        }
+
+        for (int i = 1; i <= result.getMetaData().getColumnCount(); i++) {
+            if (result.getObject(i) == null) continue;
+            BigDecimal expected = new BigDecimal(expectedStrings[i-1]);
+            BigDecimal actual = result.getBigDecimal(i).stripTrailingZeros();
+            assertEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testColumnTypeEquivalence() throws SQLException {
+        Map<String, String> jdbcColumnTypes = getColumnTypesOfTable(EXA_TABLE_JDBC);
+        Map<String, String> importColumnTypes = getColumnTypesOfTable(EXA_TABLE_IMPORT);
+
+        for (Map.Entry entry : jdbcColumnTypes.entrySet()) {
+            assertEquals(entry.getValue(), importColumnTypes.get(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void testSelectExpression() throws SQLException {
+        String query = "SELECT C7 + 1 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result, "12346.12345");
+            matchNextRowDecimal(result, "12356.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT CAST((C7 + 1) AS FLOAT) FROM " + ORA_TABLE);
+    }
+
+    @Test
+    public void testFilterExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " WHERE C7 > 12346";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, "12355.12345");
+        matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " WHERE 12346 < C7");
+    }
+
+    @Test
+    public void testAggregateSingleGroup() throws SQLException {
+        String query = "SELECT min(C7) FROM %s";
+        for(ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result,"12345.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE);
+    }
+
+    @Test
+    public void testAggregateGroupByColumn() throws SQLException {
+        String query = "SELECT C5, min(C7) FROM %s GROUP BY C5";
+        for(ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result, "123456789012345678901234567890123456", "12345.12345");
+            matchNextRowDecimal(result, "1234567890.123456789", "12355.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY C5");
+    }
+
+
+    @Test
+    public void testAggregateGroupByExpression() throws SQLException {
+        String query = "SELECT C5 + 1, min(C7) FROM %s GROUP BY C5 + 1";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result, "123456789012345678901234567890123457", "12345.12345");
+            matchNextRowDecimal(result, "1234567891.123456789", "12355.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT CAST((C5 + 1) AS FLOAT), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY (C5 + 1)");
+    }
+
+    @Test
+    public void testAggregateGroupByTuple() throws SQLException {
+        String query = "SELECT C_NUMBER36, C5, min(C7) FROM %s GROUP BY C_NUMBER36, C5 ORDER BY C5 DESC";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result, "123456789012345678901234567890123456", "123456789012345678901234567890123456", "12345.12345");
+            matchNextRowDecimal(result, "123456789012345678901234567890123456", "1234567890.123456789", "12355.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT C_NUMBER36, TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY C5, C_NUMBER36 ORDER BY C5 DESC");
+    }
+
+    @Test
+    public void testAggregateHaving() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT C5, min(C7) FROM %s GROUP BY C5 HAVING MIN(C7) > 12350";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRowDecimal(result, "1234567890.123456789", "12355.12345");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY C5 HAVING 12350 < MIN(C7)");
+    }
+
+    @Test
+    public void testOrderByColumn() throws SQLException {
+        String query = "SELECT C1 FROM %s ORDER BY C1 DESC NULLS LAST";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "aaaaaaaaaaaaaaaaaaaa                              ");
+            matchNextRow(result, (Object) null);
+        }
+        runMatchSingleRowExplain(query, "SELECT C1 FROM " + ORA_TABLE + " ORDER BY C1 DESC NULLS LAST");
+    }
+
+    @Test
+    public void testOrderByExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY ABS(C7) DESC NULLS FIRST";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, "12355.12345");
+        matchNextRow(result, "12345.12345");
+        matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " ORDER BY ABS(C7) DESC");
+    }
+
+    @Test
+    public void testLimit() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY C7 LIMIT 2";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, "12345.12345");
+        matchNextRow(result, "12355.12345");
+        matchSingleRowExplain(query, "SELECT LIMIT_SUBSELECT.* FROM ( SELECT C7 FROM " + ORA_TABLE + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2");
+    }
+
+    @Test
+    public void testLimitOffset() throws SQLException, ClassNotFoundException, FileNotFoundException {
+        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY C7 LIMIT 1 OFFSET 1";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, "12355.12345");
+        matchSingleRowExplain(query, "SELECT c0 FROM ( SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( SELECT C7 AS c0 FROM " + ORA_TABLE + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2 ) WHERE ROWNUM_SUB > 1");
+    }
+
+    @Test
+    public void testChar() throws SQLException {
+        String query = "SELECT C1 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "aaaaaaaaaaaaaaaaaaaa                              ");
+        }
+        assertEquals("CHAR(50) ASCII", getColumnType("C1"));
+    }
+
+    @Test
+    public void testNChar() throws SQLException {
+        String query = "SELECT C2 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "bbbbbbbbbbbbbbbbbbbb                              ");
+        }
+        assertEquals("CHAR(50) UTF8", getColumnType("C2"));
+    }
+
+    @Test
+    public void testVarchar() throws SQLException {
+        String query = "SELECT C3 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "cccccccccccccccccccc");
+        }
+        assertEquals("VARCHAR(50) ASCII", getColumnType("C3"));
+    }
+
+    @Test
+    public void testNVarchar() throws SQLException {
+        String query = "SELECT C4 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "dddddddddddddddddddd");
+        }
+        assertEquals("VARCHAR(50) UTF8", getColumnType("C4"));
+    }
+
+    @Test
+    public void testNumber() throws SQLException {
+        String query = "SELECT C5 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            BigDecimal expected = new BigDecimal("123456789012345678901234567890123456");
+            BigDecimal actual = result.getBigDecimal("C5");
+            assertEquals(expected, actual);
+        }
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C5"));
+    }
+
+    @Test
+    public void testNumber36() throws SQLException {
+        String query = "SELECT c_number36 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            BigDecimal expected = new BigDecimal("123456789012345678901234567890123456");
+            BigDecimal actual = result.getBigDecimal("c_number36");
+            assertEquals(expected, actual);
+        }
+        assertEquals("DECIMAL(36,0)", getColumnType("C_NUMBER36"));
+    }
+
+    @Test
+    public void testNumber38() throws SQLException {
+        String query = "SELECT C6 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            BigDecimal expected = new BigDecimal("12345678901234567890123456789012345678");
+            BigDecimal actual = result.getBigDecimal("C6");
+            assertEquals(expected, actual);
+        }
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C6"));
+    }
+
+    @Test
+    public void testNumber10S5() throws SQLException {
+        String query = "SELECT C7 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            BigDecimal expected = new BigDecimal("12345.12345");
+            BigDecimal actual = result.getBigDecimal("C7").stripTrailingZeros();
+            assertEquals(expected, actual);
+        }
+        assertEquals("DECIMAL(10,5)", getColumnType("C7"));
+    }
+
+    @Test
+    public void testBinaryFloat() throws SQLException {
+        String query = "SELECT C_BINFLOAT FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            Float expected = Float.parseFloat("1234.1241723");
+            Float actual = result.getFloat(1);
+            if (Math.abs(expected - actual) > 0.00001) {
+                fail();
+            }
+        }
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C_BINFLOAT"));
+    }
+
+    @Test
+    public void testBinaryDouble() throws SQLException {
+        String query = "SELECT C_BINDOUBLE FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            Double expected = Double.parseDouble("1234987.120871234");
+            Double actual = result.getDouble(1);
+            if (Math.abs(expected - actual) > 0.0000001) {
+                fail();
+            }
+        }
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C_BINDOUBLE"));
+    }
+
+    @Test
+    public void testFloat() throws SQLException {
+        String query = "SELECT C_FLOAT FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            Float expected = Float.parseFloat("12345.01982348239");
+            Float actual = result.getFloat(1);
+            if (Math.abs(expected - actual) > 0.000000001) {
+                fail();
+            }
+        }
+        assertEquals("DOUBLE", getColumnType("C_FLOAT"));
+    }
+
+    @Test
+    public void testFloat126() throws SQLException {
+        String query = "SELECT C_FLOAT126 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            result.next();
+            Float expected = Float.parseFloat("12345678.01234567901234567890123456789");
+            Float actual = result.getFloat(1);
+            if (Math.abs(expected - actual) > 0.00000000000000000001) {
+                fail();
+            }
+        }
+        assertEquals("DOUBLE", getColumnType("C_FLOAT126"));
+    }
+
+    @Test
+    public void testLong() throws SQLException {
+        String query = "SELECT C_LONG FROM " + EXA_TABLE_JDBC;
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, "test long 123");
+        assertEquals("VARCHAR(2000000) ASCII", getColumnType("C_LONG"));
+    }
+
+    @Test
+    public void testDate() throws SQLException {
+        String query = "SELECT C10 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, Date.valueOf("2016-08-19"));
+        }
+        runMatchSingleRowExplain(query, "SELECT C10 FROM " + ORA_TABLE);
+        assertEquals("TIMESTAMP", getColumnType("C10"));
+    }
+
+    @Test
+    public void testTimestamp3() throws SQLException {
+        String query = "SELECT C11 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "11-MAR-13 05.30.15.123 PM");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C11) FROM " + ORA_TABLE);
+        assertEquals("TIMESTAMP", getColumnType("C11"));
+    }
+
+    @Test
+    public void testTimestamp6() throws SQLException {
+        String query = "SELECT C12 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "11-MAR-13 05.30.15.123456 PM");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C12) FROM " + ORA_TABLE);
+        assertEquals("TIMESTAMP", getColumnType("C12"));
+    }
+
+    @Test
+    public void testTimestamp9() throws SQLException {
+        String query = "SELECT C13 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "11-MAR-13 05.30.15.123456789 PM");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C13) FROM " + ORA_TABLE);
+        assertEquals("TIMESTAMP", getColumnType("C13"));
+    }
+
+    @Test
+    public void testTimestampTZ() throws SQLException {
+        String query = "SELECT C14 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "19-AUG-16 11.28.05.000000 AM -08:00");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C14) FROM " + ORA_TABLE);
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C14"));
+    }
+
+    @Test
+    public void testTimestampLocalTZ() throws SQLException {
+        executeUpdate("ALTER SESSION SET TIME_ZONE = 'UTC'");
+        String query = "SELECT C15 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "30-APR-18 06.00.05.000000 PM");
+        }
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C15"));
+    }
+
+    @Test
+    public void testIntervalYear() throws SQLException {
+        String query = "SELECT C16 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "+54-02");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C16) FROM " + ORA_TABLE);
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C16"));
+    }
+
+    @Test
+    public void testIntervalDay() throws SQLException {
+        String query = "SELECT C17 FROM %s";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "+01 11:12:10.123000");
+            matchNextRow(result, "+02 02:03:04.123456");
+        }
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C17) FROM " + ORA_TABLE);
+        assertEquals("VARCHAR(2000000) UTF8", getColumnType("C17"));
+    }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
@@ -42,7 +42,8 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
                 getConfig().getOracleJdbcConnectionString(),
                 IS_LOCAL,
                 getConfig().debugAddress(),
-                "ALL_TYPES");
+                "ALL_TYPES",
+                null);
     }
 
     @Test

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import javax.print.DocFlavor;
 import java.io.FileNotFoundException;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -49,8 +50,10 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
     public static void beforeMethod() throws FileNotFoundException, SQLException, ClassNotFoundException {
         Assume.assumeTrue(getConfig().oracleTestsRequested());
         setConnection(connectToExa());
-        // createOracleJDBCAdapter();
+
+        createOracleJDBCAdapter();
         createOracleConnection();
+
         // create JDBC virtual schema
         createVirtualSchema(
                 VIRTUAL_SCHEMA_JDBC,
@@ -110,11 +113,11 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         return map;
     }
 
-    // TODO: make configurable
-    private static void createOracleConnection() throws SQLException {
-        createConnection("CONN_ORACLE",
-                "(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST = 10.44.1.186)(PORT = 1521)))(CONNECT_DATA = (SERVICE_NAME = xe)))",
-                "system", "oracle");
+    private static void createOracleConnection() throws SQLException, FileNotFoundException {
+        URI conn = getConfig().getOracleConnectionInformation();
+        String connectionString = String.format("(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCP)(HOST = %s)(PORT = %d)))(CONNECT_DATA = (SERVICE_NAME = %s)))",
+                conn.getHost(), conn.getPort(), conn.getPath().substring(1));
+        createConnection("CONN_ORACLE", connectionString, getConfig().getOracleUser(), getConfig().getOraclePassword());
     }
 
     private List<ResultSet> runQuery(String query) throws SQLException {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
@@ -165,10 +165,11 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testFilterExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " WHERE C7 > 12346";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12355.12345");
+    public void testFilterExpression() throws SQLException {
+        String query = "SELECT C7 FROM %s WHERE C7 > 12346";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "12355.12345");
+        }
         matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " WHERE 12346 < C7");
     }
 
@@ -232,28 +233,31 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testOrderByExpression() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY ABS(C7) DESC NULLS FIRST";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12355.12345");
-        matchNextRow(result, "12345.12345");
+    public void testOrderByExpression() throws SQLException {
+        String query = "SELECT C7 FROM %s ORDER BY ABS(C7) DESC NULLS FIRST";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "12355.12345");
+            matchNextRow(result, "12345.12345");
+        }
         matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " ORDER BY ABS(C7) DESC");
     }
 
     @Test
-    public void testLimit() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY C7 LIMIT 2";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12345.12345");
-        matchNextRow(result, "12355.12345");
+    public void testLimit() throws SQLException {
+        String query = "SELECT C7 FROM %s ORDER BY C7 LIMIT 2";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "12345.12345");
+            matchNextRow(result, "12355.12345");
+        }
         matchSingleRowExplain(query, "SELECT LIMIT_SUBSELECT.* FROM ( SELECT C7 FROM " + ORA_TABLE + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2");
     }
 
     @Test
-    public void testLimitOffset() throws SQLException, ClassNotFoundException, FileNotFoundException {
-        String query = "SELECT C7 FROM " + EXA_TABLE_JDBC + " ORDER BY C7 LIMIT 1 OFFSET 1";
-        ResultSet result = executeQuery(query);
-        matchNextRow(result, "12355.12345");
+    public void testLimitOffset() throws SQLException {
+        String query = "SELECT C7 FROM %s ORDER BY C7 LIMIT 1 OFFSET 1";
+        for (ResultSet result : runQuery(query)) {
+            matchNextRow(result, "12355.12345");
+        }
         matchSingleRowExplain(query, "SELECT c0 FROM ( SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( SELECT C7 AS c0 FROM " + ORA_TABLE + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2 ) WHERE ROWNUM_SUB > 1");
     }
 

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/TeradataSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/TeradataSqlDialectIT.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 
 import java.io.FileNotFoundException;
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -40,7 +39,7 @@ public class TeradataSqlDialectIT extends AbstractIntegrationTest {
                 getConfig().getTeradataJdbcConnectionString(),
                 false,
                 getConfig().debugAddress(),
-                "numeric_data_types, REGION, DateTime_and_Interval_Data_Types, Period_Data_Types");
+                "numeric_data_types, REGION, DateTime_and_Interval_Data_Types, Period_Data_Types", null);
     }
 
 //    @Test


### PR DESCRIPTION
This pull request addresses the feature described by issue #26. Changes include:
- The virtual schema parameters `IMPORT_FROM_ORA` and `ORA_CONNECTION_NAME` are added.
- The function `JdbcAdapter.handlePushdownRequest()` is extended to generate `IMPORT FROM ORA` queries.
- (Almost) all Oracle data types are tested (see class `OracleSqlDialectIT`). All tests are run twice; once over a JDBC and once over an IMPORT FROM ORA connection.
- `oracle-testdata.sql` is included which prepares an Oracle table that is used by the Oracle integration tests.
