### PR TITLE
Add script to run Exasol integration tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: java
 
-# Setting sudo to false will cause Travis to use Containers (default in the meantime)
-sudo: false
+# Setting sudo to false will cause Travis to use Containers.
+# To use Docker's privileged mode, we need to enable sudo.
+sudo: required
+
+services:
+  - docker
 
 matrix:
   include:
     - jdk: "oraclejdk8"
-      env: MVN_ARGS=""
 
-# build a jar with all dependencies. Will also run tests.
-script: "cd jdbc-adapter && mvn $MVN_ARGS clean package"
-
+script: ./jdbc-adapter/integration-test-data/run_integration_tests.sh

--- a/jdbc-adapter/integration-test-data/EXAConf
+++ b/jdbc-adapter/integration-test-data/EXAConf
@@ -1,0 +1,124 @@
+[Global]
+    Revision = 11
+    Checksum = NONE
+    ClusterName = cl4
+    Platform = Docker
+    LicenseFile = /exa/etc/license.xml
+    CoredPort = 10001
+    SSHPort = 22
+    # The type of networks for this cluster: 'public', 'private' or both.
+    Networks = private
+    # Comma-separated list of nameservers for this cluster.
+    NameServers =
+    ConfVersion = 6.0.10
+    OSVersion = 6.0.10
+    DBVersion = 6.0.10
+    ImageVersion = 6.0.10-d1
+
+# SSL options
+[SSL]
+    # The SSL certificate, private key and CA for all EXASOL services
+    Cert = /path/to/ssl.crt
+    CertKey = /path/to/ssl.key
+    CertAuth = /path/to/ssl.ca
+
+# Docker related options
+[Docker]
+    # The directory that contains all data related to this docker cluster
+    # (except for mapped devices)
+    RootDir = /exa/etc
+    # The EXASOL docker image used for all containers of this cluster
+    Image = exasol/docker-db:6.0.10-d1
+    # The type of storage devices for this cluster: 'block' or 'file'
+    DeviceType = file
+
+[Node : 11]
+    PrivateNet = 172.17.0.2/16
+    PublicNet =
+    Name = n11
+    UUID = 5D11CDFCDEA74475833F1892426428873D4BEB66
+    DockerVolume = n11
+    # Ports to be exposed (container : host)
+    ExposedPorts = 8888:8899, 6583:6594
+    [[Disk : default]]
+        Devices = dev.1
+        Mapping = dev.1:/exa/data/storage
+
+# Global EXAStorage options
+[EXAStorage]
+    # Max. throughput for background recovery / data restoration (in MiB/s)
+    RecLimit =
+
+# An EXAStorage data volume
+[EXAVolume : DataVolume1]
+    # Type of volume: 'data' | 'archive'
+    Type = data
+    # Comma-separated list of node IDs to be used for this volume (incl. redundancy nodes)
+    Nodes = 11,
+    # Name of the disk to be used for this volume.
+    # This disk must exist on all volume nodes.
+    Disk = default
+    # Volume size (e. g. '1 TiB')
+    Size = 2.0 GiB
+    # Desired redundancy for this volume
+    Redundancy = 1
+    # Volume owner (user and group ID)
+    Owner = 500 : 500
+    # OPTIONAL: a comma-separated list of labels for this volume
+    Labels =
+
+# An EXASOL database
+[DB : DB1]
+    DataVolume = DataVolume1
+    ArchiveVolume =
+    # The EXASOL version to be used for this database
+    Version = 6.0.10
+    # User and group ID that should own this database
+    Owner = 500 : 500
+    # Memory size over all nodes (e. g. '1 TiB')
+    MemSize = 2 GiB
+    Port = 8888
+    Nodes = 11,
+    NumMasterNodes = 1
+    # OPTIONAL: DB parameters
+    Params = -etlJdbcJavaEnv -Djava.security.egd=/dev/./urandom
+    # OPTIONAL: JDBC driver configuration
+    [[JDBC]]
+        # BucketFS that contains the JDBC driver
+        BucketFS = bfsdefault
+        # Bucket that contains the JDBC driver
+        Bucket = default
+        # Directory within the bucket that contains the drivers
+        Dir = drivers/jdbc
+    # OPTIONAL: Oracle driver configuration
+    [[Oracle]]
+        # BucketFS that contains the JDBC drivers
+        BucketFS = bfsdefault
+        # Bucket that contains the JDBC drivers
+        Bucket = default
+        # Directory within the bucket that contains the drivers
+        Dir = drivers/oracle
+
+# Global BucketFS options
+[BucketFS]
+    # User and group ID of the BucketFS process.
+    ServiceOwner = 500 : 500
+
+# A Bucket filesystem
+[BucketFS : bfsdefault]
+    # HTTP port number (0 = disabled)
+    HttpPort = 6583
+    # HTTPS port number (0 = disabled)
+    HttpsPort = 0
+    SyncKey = OHNNMEJTV09aeEFyajhjYVBnTmtsQ0E2MjhWMDRlYzI=
+    SyncPeriod = 30000
+
+    # A bucket
+    [[Bucket : default]]
+        # ReadPasswd is "read" (without quotes)
+        ReadPasswd = cmVhZAo=
+        # WritePasswd is "write" (without quotes)
+        WritePasswd = d3JpdGU=
+        Public = True
+        Name = default
+        AdditionalFiles = EXAClusterOS:/usr/opt/EXASuite-6/EXAClusterOS-6.0.10/var/clients/packages/ScriptLanguages-*, EXASolution-6.0.10:/usr/opt/EXASuite-6/EXASolution-6.0.10/bin/udf/*

--- a/jdbc-adapter/integration-test-data/integration-test-travis.yaml
+++ b/jdbc-adapter/integration-test-data/integration-test-travis.yaml
@@ -1,0 +1,14 @@
+# Configuration file for integration tests run by `run_integration_tests.sh`
+
+general:
+  debug:            false
+  debugAddress:     ''
+  bucketFsUrl:      http://127.0.0.1:6594/default
+  bucketFsPassword: write
+  jdbcAdapterPath:  /buckets/bfsdefault/default/virtualschema-jdbc-adapter-dist-1.0.2-SNAPSHOT.jar
+
+exasol:
+  runIntegrationTests: true
+  address:  127.0.0.1:8899
+  user:     sys
+  password: exasol

--- a/jdbc-adapter/integration-test-data/run_integration_tests.sh
+++ b/jdbc-adapter/integration-test-data/run_integration_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# This script executes integration tests as defined in
+# integration-test-travis.yaml (currently only Exasol integration tests).
+
+# An Exasol instance is run using the exasol/docker-db image. Therefore, a
+# working installation of Docker and sudo privileges are required.
+
+set -eux
+
+cd "$(dirname "$0")/.."
+
+config="$(pwd)/integration-test-data/integration-test-travis.yaml"
+
+function cleanup() {
+    docker rm -f exasoldb || true
+    sudo rm -rf integration-test-data/exa || true
+}
+trap cleanup EXIT
+
+# Setup directory "exa" with pre-configured EXAConf to attach it to the exasoldb docker container
+mkdir -p integration-test-data/exa/{etc,data/storage}
+cp integration-test-data/EXAConf integration-test-data/exa/etc/EXAConf
+dd if=/dev/zero of=integration-test-data/exa/data/storage/dev.1.data bs=1 count=1 seek=4G
+touch integration-test-data/exa/data/storage/dev.1.meta
+
+docker pull exasol/docker-db:latest
+docker run \
+    --name exasoldb \
+    -p 8899:8888 \
+    -p 6594:6583 \
+    --detach \
+    --privileged \
+    -v "$(pwd)/integration-test-data/exa:/exa" \
+    exasol/docker-db:latest \
+    init-sc --node-id 11
+
+docker logs -f exasoldb &
+
+# Wait until database is ready
+(docker logs -f --tail 0 exasoldb &) 2>&1 | grep -q -i 'stage4: All stages finished'
+sleep 30
+
+mvn -q clean package
+
+# Load virtualschema-jdbc-adapter jar into BucketFS and wait until it's available.
+mvn -q pre-integration-test -DskipTests -Pit -Dintegrationtest.configfile="$config"
+(docker exec exasoldb sh -c 'tail -f -n +0 /exa/logs/cored/*bucket*' &) | \
+    grep -q -i 'File.*virtualschema-jdbc-adapter.*linked'
+
+mvn -q verify -Pit -Dintegrationtest.configfile="$config" -Dintegrationtest.skipTestSetup=true

--- a/jdbc-adapter/virtualschema-jdbc-adapter/pom.xml
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/pom.xml
@@ -26,6 +26,7 @@
             <properties>
                 <!-- This property has to be overwritten from user -->
                 <integrationtest.configfile></integrationtest.configfile>
+                <integrationtest.skipTestSetup>false</integrationtest.skipTestSetup>
             </properties>
             <build>
                 <plugins>
@@ -79,6 +80,7 @@
                                         <argument>com.exasol.adapter.dialects.IntegrationTestSetup</argument>
                                         <argument>${project.version}</argument>
                                         <argument>${integrationtest.configfile}</argument>
+                                        <argument>${integrationtest.skipTestSetup}</argument>
                                     </arguments>
                                 </configuration>
                             </execution>

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/IntegrationTestSetup.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/IntegrationTestSetup.java
@@ -25,6 +25,13 @@ import org.apache.http.impl.client.HttpClientBuilder;
 public class IntegrationTestSetup {
 
     public static void main(String[] args) throws IOException, InterruptedException, URISyntaxException {
+        if (args.length > 2) {
+            Boolean skipTestSetup = Boolean.valueOf(args[2]);
+            if (skipTestSetup) {
+                System.out.println("Skip setup of the integration test environment");
+                return;
+            }
+        }
 
         System.out.println("Start setup of the integration test environment");
         String projectVersion = args[0];


### PR DESCRIPTION
A new shell script `run_integration_tests.sh` executes the integration tests as definied in `integration-test-travis.yaml`. It uses the `exasol/docker-db` image to spin up an Exasol instance and execute the Exasol dialect integration tests.

Travis CI automatically executes the test script for each new commit.
