### PR TITLE
Readme fixes

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -26,16 +26,16 @@ There are the following request and response types:
 
 | Type                        | Called ...     |
 | :-------------------------- | :------------- |
-| **Create Virtual Schema**   | ... for each ```CREATE VIRTUAL SCHEMA ...``` statement |
-| **Refresh**                 | ... for each ```ALTER VIRTUAL SCHEMA ... REFRESH ...``` statement. |
-| **Set Properties**          | ... for each ```ALTER VIRTUAL SCHEMA ... SET ...``` statement. |
-| **Drop Virtual Schema**     | ... for each ```DROP VIRTUAL SCHEMA ...``` statement. |
-| **Get Capabilities**        | ... whenever a virtual table is queried in a ```SELECT``` statement. |
-| **Pushdown**                | ... whenever a virtual table is queried in a ```SELECT``` statement. |
+| **Create Virtual Schema**   | ... for each `CREATE VIRTUAL SCHEMA ...` statement |
+| **Refresh**                 | ... for each `ALTER VIRTUAL SCHEMA ... REFRESH ...` statement. |
+| **Set Properties**          | ... for each `ALTER VIRTUAL SCHEMA ... SET ...` statement. |
+| **Drop Virtual Schema**     | ... for each `DROP VIRTUAL SCHEMA ...` statement. |
+| **Get Capabilities**        | ... whenever a virtual table is queried in a `SELECT` statement. |
+| **Pushdown**                | ... whenever a virtual table is queried in a `SELECT` statement. |
 
 We describe each of the types in the following sections.
 
-**Please note:** To keep the documentation concise we defined the elements which are commonly in separate sections below, e.g. ```schemaMetadataInfo``` and ```schemaMetadata```.
+**Please note:** To keep the documentation concise we defined the elements which are commonly in separate sections below, e.g. `schemaMetadataInfo` and `schemaMetadata`.
 
 ## Requests and Responses
 
@@ -68,7 +68,7 @@ The Adapter is allowed to throw an Exception if the user missed to provide manda
 ```
 
 Notes
-* ```schemaMetadata``` is mandatory. However, it is allowed to contain no tables.
+* `schemaMetadata` is mandatory. However, it is allowed to contain no tables.
 
 
 ### Refresh
@@ -88,7 +88,7 @@ Request to refresh the metadata for the whole Virtual Schema, or for specified t
 ```
 
 Notes
-* ```requestedTables``` is optional. If existing, only the specified tables shall be refreshed. The specified tables do not have to exist, it just tell Adapter to update these tables (which might be changed, deleted, added, or non-existing).
+* `requestedTables` is optional. If existing, only the specified tables shall be refreshed. The specified tables do not have to exist, it just tell Adapter to update these tables (which might be changed, deleted, added, or non-existing).
 
 **Response:**
 
@@ -103,8 +103,8 @@ Notes
 ```
 
 Notes
-* ```schemaMetadata``` is optional. It can be skipped if the adapter does not want to refresh (e.g. because he detected that there is no change).
-* ```requestedTables``` must exist if and only if the element existed in the request. The values must be the same as in the request (to make sure that Adapter only refreshed these tables).
+* `schemaMetadata` is optional. It can be skipped if the adapter does not want to refresh (e.g. because he detected that there is no change).
+* `questedTables` must exist if and only if the element existed in the request. The values must be the same as in the request (to make sure that Adapter only refreshed these tables).
 
 ### Set Properties
 
@@ -139,7 +139,7 @@ Request to set properties. The Adapter can decide whether he needs to send back 
 
 Notes
 * Request: A property set to null means that this property was asked to be deleted. Properties set to null might also not have existed before.
-* Response: ```schemaMetadata``` is optional. It only exists if the adapter wants to send back new metadata. The existing metadata are overwritten completely.
+* Response: `schemaMetadata` is optional. It only exists if the adapter wants to send back new metadata. The existing metadata are overwritten completely.
 
 
 ### Drop Virtual Schema
@@ -400,17 +400,17 @@ will produce the following Request, assuming that the Adapter has all required c
 ```
 
 Notes
-* ```pushdownRequest```: Specification what needs to be pushed down. You can think of it like a parsed SQL statement.
-  * ```from```: The requested from clause. Currently only tables are supported, joins might be supported in future.
-  * ```selectList```: The requested select list elements, a list of expression. The order of the selectlist elements matters. If the select list is an empty list, we request at least a single column/expression, which could also be constant TRUE.
-  * ```selectList.columnNr```: Position of the column in the virtual table, starting with 0
-  * ```filter```: The requested filter (where clause), a single expression.
-  * ```aggregationType```: Optional element, set if an aggregation is requested. Either "group_by" or "single_group", if a aggregate function is used but no group by.
-  * ```groupBy```: The requested group by clause, a list of expressions.
-  * ```having```: The requested having clause, a single expression.
-  * ```orderBy```: The requested order-by clause, a list of ```order_by_element``` elements. The field ```expression``` contains the expression to order by.
-  * ```limit``` The requested limit of the result set, with an optional offset.
-* ```involvedTables```: Metadata of the involved tables, encoded like in schemaMetadata.
+* `pushdownRequest`: Specification what needs to be pushed down. You can think of it like a parsed SQL statement.
+  * `from`: The requested from clause. Currently only tables are supported, joins might be supported in future.
+  * `selectList`: The requested select list elements, a list of expression. The order of the selectlist elements matters. If the select list is an empty list, we request at least a single column/expression, which could also be constant TRUE.
+  * `selectList.columnNr`: Position of the column in the virtual table, starting with 0
+  * `filter`: The requested filter (`where` clause), a single expression.
+  * `aggregationType`Optional element, set if an aggregation is requested. Either `group_by` or `single_group`, if a aggregate function is used but no group by.
+  * `groupBy`: The requested group by clause, a list of expressions.
+  * `having`: The requested having clause, a single expression.
+  * `orderBy`: The requested order-by clause, a list of `order_by_element` elements. The field `expression` contains the expression to order by.
+  * `limit` The requested limit of the result set, with an optional offset.
+* `involvedTables`: Metadata of the involved tables, encoded like in schemaMetadata.
 
 
 **Response:**
@@ -425,14 +425,14 @@ Following the example above, a valid result could look like this:
 ```
 
 Notes
-* ```sql```: The pushdown SQL statement. It must be either an ```SELECT``` or ```IMPORT``` statement.
+* `sql`: The pushdown SQL statement. It must be either an `SELECT` or `IMPORT` statement.
 
 ## Embedded Commonly Used JSON Elements
 
 The following Json objects can be embedded in a request or response. They have a fixed structure.
 
 ### Schema Metadata Info
-This document contains the most important metadata of the virtual schema and is sent to the adapter just "for information" with each request. It is the value of an element called ```schemaMetadataInfo```.
+This document contains the most important metadata of the virtual schema and is sent to the adapter just "for information" with each request. It is the value of an element called `schemaMetadataInfo`.
 
 ```json
 {"schemaMetadataInfo":{
@@ -451,7 +451,7 @@ This document contains the most important metadata of the virtual schema and is 
 
 ### Schema Metadata
 
-This document is usually embedded in responses from the Adapter and informs the database about all metadata of the Virtual Schema, especially the contained Virtual Tables and it's columns. The Adapter can store so called ```adapterNotes``` on each level (schema, table, column), to remember information which might be relevant for the Adapter in future. In the example below, the Adapter remembers the table partitioning and the data type of a column which is not directly supported in EXASOL. The Adapter has these information during pushdown and can consider the table partitioning during pushdown or can add an appropriate cast for the column.
+This document is usually embedded in responses from the Adapter and informs the database about all metadata of the Virtual Schema, especially the contained Virtual Tables and it's columns. The Adapter can store so called `adapterNotes` on each level (schema, table, column), to remember information which might be relevant for the Adapter in future. In the example below, the Adapter remembers the table partitioning and the data type of a column which is not directly supported in EXASOL. The Adapter has these information during pushdown and can consider the table partitioning during pushdown or can add an appropriate cast for the column.
 
 ```json
 {"schemaMetadata":{
@@ -526,7 +526,7 @@ This document is usually embedded in responses from the Adapter and informs the 
 ```
 
 Notes
-* ```adapterNotes``` is an optional field which can be attached to the schema, a table or a column. It can be an arbitrarily nested Json document.
+* `adapterNotes` is an optional field which can be attached to the schema, a table or a column. It can be an arbitrarily nested Json document.
 
 The following EXASOL data types are supported:
 
@@ -767,7 +767,7 @@ This element currently only occurs in from clause
 
 Notes
 * **tablePosFromClause**: Position of the table in the from clause, starting with 0. Required for joins where same table occurs several times.
-* **columnNr**: column number in the virtual table, starting with 0
+* **columnNr**: Column number in the virtual table, starting with 0.
 
 ### Literal
 
@@ -828,7 +828,7 @@ Notes
 
 ### Predicates
 
-Whenever there is ```...``` this is a shortcut for an arbitrary expression.
+Whenever there is `...` this is a shortcut for an arbitrary expression.
 
 ```json
 {
@@ -839,7 +839,7 @@ Whenever there is ```...``` this is a shortcut for an arbitrary expression.
 }
 ```
 
-The same can be used for "predicate_or".
+The same can be used for `predicate_or`.
 
 ```json
 {
@@ -862,7 +862,7 @@ The same can be used for "predicate_or".
 }
 ```
 
-The same can be used for "predicate_notequals", "predicate_less" and "predicate_lessequals".
+The same can be used for `predicate_notequals`, `predicate_less` and `predicate_lessequals`.
 
 ```json
 {
@@ -877,7 +877,7 @@ The same can be used for "predicate_notequals", "predicate_less" and "predicate_
 }
 ```
 
-The same can be used for predicate_like_regexp
+The same can be used for `predicate_like_regexp`.
 
 Notes
 * **escapeChar** is optional
@@ -897,7 +897,7 @@ Notes
 }
 ```
 
-<exp> IN (<const1>, <const2>)
+`<exp> IN (<const1>, <const2>)`
 
 ```json
 {
@@ -966,9 +966,9 @@ Multiple arguments
 ```
 
 Notes
-* **variableInputArgs**: default value is false. If true, numArgs is not defined.
+* **variableInputArgs**: default value is false. If true, `numArgs` is not defined.
 
-Arithmetic operators have following names: ADD, SUB, MULT, FLOAT_DIV. They are defined as infix (just a hint, not necessary)
+Arithmetic operators have following names: `ADD`, `SUB`, `MULT`, `FLOAT_DIV`. They are defined as infix (just a hint, not necessary).
 
 ```json
 {
@@ -989,7 +989,7 @@ Arithmetic operators have following names: ADD, SUB, MULT, FLOAT_DIV. They are d
 
 **Special cases**
 
-EXTRACT(toExtract FROM exp1) (requires scalar-function capability EXTRACT) 
+`EXTRACT(toExtract FROM exp1)` (requires scalar-function capability `EXTRACT`) 
 
 ```json
 {
@@ -1003,7 +1003,7 @@ EXTRACT(toExtract FROM exp1) (requires scalar-function capability EXTRACT)
     ],
 }
 ```
-CAST(exp1 AS dataType) (requires scalar-function capability CAST) 
+`CAST(exp1 AS dataType)` (requires scalar-function capability `CAST`)
 
 ```json
 {
@@ -1022,7 +1022,7 @@ CAST(exp1 AS dataType) (requires scalar-function capability CAST)
 }
 ```
 
-CASE (requires scalar-function capability CAST)
+`CASE` (requires scalar-function capability `CAST`)
 
 ```sql
 CASE basis WHEN exp1 THEN result1
@@ -1069,13 +1069,12 @@ CASE basis WHEN exp1 THEN result1
 }
 ```
 Notes:
-* ```arguments```: The different cases.
-* ```results```: The different results in the same order as the arguments. If present, the ELSE result
-is the last entry in the ```results``` array.
+* `arguments`: The different cases.
+* `results`: The different results in the same order as the arguments. If present, the ELSE result is the last entry in the `results` array.
 
 ### Aggregate Functions
 
-Consistent with scalar functions. To be detailed: star-operator, distinct, ...
+Consistent with scalar functions. To be detailed: `star-operator`, `distinct`, ...
 
 ```json
 {
@@ -1106,7 +1105,7 @@ Consistent with scalar functions. To be detailed: star-operator, distinct, ...
 
 **Special cases**
 
-COUNT(exp)     (requires set-function capability COUNT)
+`COUNT(exp)`     (requires set-function capability `COUNT`)
 
 ```json
 {
@@ -1120,7 +1119,7 @@ COUNT(exp)     (requires set-function capability COUNT)
 }
 ```
 
-COUNT(*) (requires set-function capability COUNT and COUNT_STAR)
+`COUNT(*)` (requires set-function capability `COUNT` and `COUNT_STAR`)
 
 ```json
 {
@@ -1129,7 +1128,7 @@ COUNT(*) (requires set-function capability COUNT and COUNT_STAR)
 }
 ```
 
-COUNT(DISTINCT exp)    (requires set-function capability COUNT and COUNT_DISTINCT)
+`COUNT(DISTINCT exp)`    (requires set-function capability `COUNT` and `COUNT_DISTINCT`)
 
 ```json
 {
@@ -1144,7 +1143,7 @@ COUNT(DISTINCT exp)    (requires set-function capability COUNT and COUNT_DISTINC
 }
 ```
 
-COUNT((exp1, exp2))   (requires set-function capability COUNT and COUNT_TUPLE)
+`COUNT((exp1, exp2))`   (requires set-function capability `COUNT` and `COUNT_TUPLE`)
 
 ```json
 {
@@ -1161,7 +1160,7 @@ COUNT((exp1, exp2))   (requires set-function capability COUNT and COUNT_TUPLE)
     ]
 }
 ```
-AVG(exp)     (requires set-function capability AVG)
+`AVG(exp)`     (requires set-function capability `AVG`)
 
 ```json
 {
@@ -1175,7 +1174,7 @@ AVG(exp)     (requires set-function capability AVG)
 }
 ```
 
-AVG(DISTINCT exp)    (requires set-function capability AVG and AVG_DISTINCT)
+`AVG(DISTINCT exp)`    (requires set-function capability `AVG` and `AVG_DISTINCT`)
 
 ```json
 {
@@ -1190,7 +1189,7 @@ AVG(DISTINCT exp)    (requires set-function capability AVG and AVG_DISTINCT)
 }
 ```
 
-GROUP_CONCAT(DISTINCT exp1 orderBy SEPARATOR ', ') (requires set-function capability GROUP_CONCAT)
+`GROUP_CONCAT(DISTINCT exp1 orderBy SEPARATOR ', ')` (requires set-function capability `GROUP_CONCAT`)
 
 ```json
 {
@@ -1221,6 +1220,6 @@ GROUP_CONCAT(DISTINCT exp1 orderBy SEPARATOR ', ') (requires set-function capabi
 ```
 
 Notes:
-* ```distinct```: Optional. Requires set-function capability GROUP_CONCAT_DISTINCT.
-* ```orderBy```: Optional. The requested order-by clause, a list of ```order_by_element``` elements. The field ```expression``` contains the expression to order by. The group-by clause of a SELECT query uses the same ```order_by_element``` element type. The clause requires the set-function capability GROUP_CONCAT_ORDER_BY.
-* ```separator```: Optional. Requires set-function capability GROUP_CONCAT_SEPARATOR.
+* `distinct`: Optional. Requires set-function capability `GROUP_CONCAT_DISTINCT.`
+* `orderBy`: Optional. The requested order-by clause, a list of `order_by_element` elements. The field `expression` contains the expression to order by. The `group by` clause of a `SELECT` query uses the same `order_by_element` element type. The clause requires the set-function capability `GROUP_CONCAT_ORDER_BY`.
+* `separator`: Optional. Requires set-function capability `GROUP_CONCAT_SEPARATOR`.

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -97,6 +97,7 @@ Property                    | Value
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
 
 **Mandatory Connection Specification:**
+
 Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`, `USERNAME` and `PASSWORD`.
 
 Property                    | Value

--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -18,10 +18,10 @@ The JDBC adapter currently supports the following SQL dialects and data sources.
 
 Each such implementation of a dialect handles three major aspects:
 * How to **map the tables** in the source systems to virtual tables in Exasol, including how to **map the data types** to Exasol data types.
-* How is the **SQL syntax** of the data source, including identifier quoting, case-sensitivity, function names, or special syntax like LIMIT/TOP.
+* How is the **SQL syntax** of the data source, including identifier quoting, case-sensitivity, function names, or special syntax like `LIMIT`/`TOP`.
 * Which **capabilities** are supported by the data source. E.g. is it supported to run filters, to specify select list expressions, to run aggregation or scalar functions or to order or limit the result.
 
-In addition to the aforementioned dialects there is the so called ```GENERIC``` dialect, which is designed to work with any JDBC driver. It derives the SQL dialect from the JDBC driver metadata. However, it does not support any capabilities and might fail if the data source has special syntax or data types, so it should only be used for evaluation purposes.
+In addition to the aforementioned dialects there is the so called `GENERIC` dialect, which is designed to work with any JDBC driver. It derives the SQL dialect from the JDBC driver metadata. However, it does not support any capabilities and might fail if the data source has special syntax or data types, so it should only be used for evaluation purposes.
 
 If you are interested in a introduction to virtual schemas please refer to the Exasol user manual. You can find it in the [download area of the Exasol user portal](https://www.exasol.com/portal/display/DOWNLOAD/6.0).
 
@@ -58,7 +58,7 @@ SELECT count(*) FROM clicks;
 SELECT DISTINCT USER_ID FROM clicks;
 ```
 
-Behind the scenes the Exasol command ```IMPORT FROM JDBC``` will be executed to obtain the data needed from the data source to fulfil the query. The Exasol database interacts with the adapter to pushdown as much as possible to the data source (e.g. filters, aggregations or order by/limit), while considering the capabilities of the data source.
+Behind the scenes the Exasol command `IMPORT FROM JDBC` will be executed to obtain the data needed from the data source to fulfil the query. The Exasol database interacts with the adapter to pushdown as much as possible to the data source (e.g. filters, aggregations or `ORDER BY`/`LIMIT`), while considering the capabilities of the data source.
 
 Let's combine a virtual and a native tables in a query:
 ```
@@ -97,14 +97,14 @@ Property                    | Value
 **SQL_DIALECT**             | Name of the SQL dialect: EXASOL, HIVE, IMPALA, ORACLE, TERADATA, REDSHIFT or GENERIC (case insensitive). If you try generating a virtual schema without specifying this property you will see all available dialects in the error message.
 
 **Mandatory Connection Specification:**
-Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`,String `USERNAME` and `PASSWORD`.
+Either specify `CONNECTION_NAME` OR provide `CONNECTION_STRING`, `USERNAME` and `PASSWORD`.
 
 Property                    | Value
 --------------------------- | -----------
-**CONNECTION_NAME**         | Name of the connection created with `CREATE CONNECTION` which contains the JDBC connection string, the username and password. If you defined this property then it is not allowed to set CONNECTION_STRING, USERNAME and PASSWORD. We recommend using this property to ensure that the password will not be shown in the logfiles.
-**CONNECTION_STRING**       | The JDBC connection string. Only required if CONNECTION_NAME is not set.
-**USERNAME**                | Username for authentication. Only required if CONNECTION_NAME is not set.
-**PASSWORD**                | Password for authentication. Only required if CONNECTION_NAME is not set.
+**CONNECTION_NAME**         | Name of the connection created with `CREATE CONNECTION` which contains the JDBC connection string, the username and password. If you defined this property then it is not allowed to set `CONNECTION_STRING`, `USERNAME` and `PASSWORD`. We recommend using this property to ensure that the password will not be shown in the logfiles.
+**CONNECTION_STRING**       | The JDBC connection string. Only required if `CONNECTION_NAME` is not set.
+**USERNAME**                | Username for authentication. Only required if `CONNECTION_NAME` is not set.
+**PASSWORD**                | Password for authentication. Only required if `CONNECTION_NAME` is not set.
 
 
 **Common Optional Properties:**
@@ -119,32 +119,32 @@ Property                    | Value
 
 Property                    | Value
 --------------------------- | -----------
-**IMPORT_FROM_EXA**         | Only relevant if your data source is EXASOL. Either 'TRUE' or 'FALSE' (default). If true, IMPORT FROM EXA will be used for the pushdown instead of IMPORT FROM JDBC. You have to define EXA_CONNECTION_STRING if this property is true.
-**EXA_CONNECTION_STRING**   | The connection string used for IMPORT FROM EXA in the format 'hostname:port'.
-**IMPORT_FROM_ORA**         | Similar to IMPORT_FROM_EXA but for an Oracle data source. If enabled, the more performant `IMPORT FROM ORA` operation will be used in place of `IMPORT FROM JDBC`. You also need to define ORA_CONNECTION_NAME if this property is set to 'TRUE'.
+**IMPORT_FROM_EXA**         | Only relevant if your data source is EXASOL. Either `TRUE` or `FALSE` (default). If true, `IMPORT FROM EXA` will be used for the pushdown instead of `IMPORT FROM JDBC`. You have to define `EXA_CONNECTION_STRING` if this property is true.
+**EXA_CONNECTION_STRING**   | The connection string used for `IMPORT FROM EXA` in the format 'hostname:port'.
+**IMPORT_FROM_ORA**         | Similar to `IMPORT_FROM_EXA` but for an Oracle data source. If enabled, the more performant `IMPORT FROM ORA` operation will be used in place of `IMPORT FROM JDBC`. You also need to define `ORA_CONNECTION_NAME` if this property is set to `TRUE`.
 **ORA_CONNECTION_NAME**     | Name of the connection to an Oracle database created with `CREATE CONNECTION`. Used by `IMPORT FROM ORA`.
-**IS_LOCAL**                | Only relevant if your data source is the same Exasol database where you create the virtual schema. Either 'TRUE' or 'FALSE' (default). If true, you are connecting to the local Exasol database (e.g. for testing purposes). In this case, the adapter can avoid the IMPORT FROM JDBC overhead.
-**EXCEPTION_HANDLING**      | Activates or deactivates different exception handling modes. Supported values: 'IGNORE_INVALID_VIEWS', 'NONE' (default). Currently this property only affects the Teradata dialect.
+**IS_LOCAL**                | Only relevant if your data source is the same Exasol database where you create the virtual schema. Either `TRUE` or `FALSE` (default). If true, you are connecting to the local Exasol database (e.g. for testing purposes). In this case, the adapter can avoid the `IMPORT FROM JDBC` overhead.
+**EXCEPTION_HANDLING**      | Activates or deactivates different exception handling modes. Supported values: `IGNORE_INVALID_VIEWS` and `NONE` (default). Currently this property only affects the Teradata dialect.
 
 
 ## Debugging
 To see all communication between the database and the adapter you can use the python script udf_debug.py located in the [tools](tools) directory.
 
-First, start the udf_debug.py script, which will listen on the specified address and print all incoming text.
+First, start the `udf_debug.py` script, which will listen on the specified address and print all incoming text.
 ```
 python tools/udf_debug.py -s myhost -p 3000
 ```
 
-Then run following SQL statement in your session to redirect all stdout and stderr from the adapter script to the udf_debug.py script we started before.
+Then run following SQL statement in your session to redirect all stdout and stderr from the adapter script to the `udf_debug.py` script we started before.
 ```sql
 ALTER SESSION SET SCRIPT_OUTPUT_ADDRESS='host-where-udf-debug-script-runs:3000'
 ```
 
-You have to make sure that Exasol can connect to the host running the udf_debug.py script.
+You have to make sure that Exasol can connect to the host running the `udf_debug.py` script.
 
 
 ## Frequent Issues
-* **Error: No suitable driver found for JDBC...**: The JDBC driver class was not discovered automatically. Either you have to add a META-INF/services/java.sql.Driver file with the classname to your jar, or you have to load the driver manually (see JdbcMetadataReader.readRemoteMetadata()).
+* **Error: No suitable driver found for JDBC...**: The JDBC driver class was not discovered automatically. Either you have to add a `META-INF/services/java.sql.Driver` file with the classname to your jar, or you have to load the driver manually (see `JdbcMetadataReader.readRemoteMetadata()`).
 See https://docs.oracle.com/javase/7/docs/api/java/sql/DriverManager.html
 * **Very slow execution of queries with SCRIPT_OUTPUT_ADDRESS**: If `SCRIPT_OUTPUT_ADDRESS` is set as explained in the [debugging section](#debugging), verify that a service is actually listening at that address. Otherwise, if Exasol can not establish a connection, repeated connection attempts can be the cause for slowdowns.
 * **Very slow execution of queries**: Depending on which JDK version Exasol uses to execute Java user-defined functions, a blocking randomness source may be used by default. Especially cryptographic operations do not complete until the operating system has collected a sufficient amount of entropy. This problem seems to occur most often when Exasol is run in an isolated environment, e.g., a virtual machine or a container. A solution is to use a non-blocking randomness source. 

--- a/jdbc-adapter/doc/deploy-adapter.md
+++ b/jdbc-adapter/doc/deploy-adapter.md
@@ -21,15 +21,15 @@ cd virtual-schemas/jdbc-adapter/
 mvn clean -DskipTests package
 ```
 
-The resulting fat jar is stored in ```virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.0.2-SNAPSHOT.jar```.
+The resulting fat jar is stored in `virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.0.2-SNAPSHOT.jar`.
 
 ### 3. Upload Adapter Jar
 
 You have to upload the jar of the adapter to a bucket of your choice in the EXASOL bucket file system (BucketFS). This will allow using the jar in the adapter script.
 
 Following steps are required to upload a file to a bucket:
-* Make sure you have a bucket file system (BucketFS) and you know the port for either http or https. This can be done in EXAOperation under "EXABuckets". E.g. the id could be ```bucketfs1``` and the http port 2580.
-* Check if you have a bucket in the BucketFS. Simply click on the name of the BucketFS in EXAOperation and add a bucket there, e.g. ```bucket1```. Also make sure you know the write password. For simplicity we assume that the bucket is defined as a public bucket, i.e. it can be read by any script.
+* Make sure you have a bucket file system (BucketFS) and you know the port for either http or https. This can be done in EXAOperation under "EXABuckets". E.g. the id could be `bucketfs1` and the http port 2580.
+* Check if you have a bucket in the BucketFS. Simply click on the name of the BucketFS in EXAOperation and add a bucket there, e.g. `bucket1`. Also make sure you know the write password. For simplicity we assume that the bucket is defined as a public bucket, i.e. it can be read by any script.
 * Now upload the file into this bucket, e.g. using curl (adapt the hostname, BucketFS port, bucket name and bucket write password).
 ```
 curl -X PUT -T virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.0.2-SNAPSHOT.jar \

--- a/jdbc-adapter/doc/develop-dialect.md
+++ b/jdbc-adapter/doc/develop-dialect.md
@@ -6,7 +6,7 @@ This page describes how you can develop and semi-automatically test a dialect fo
 * [How To Start Integration Tests](#how-to-start-integration-tests)
 
 ## How To Develop a Dialect
-You can implement a dialect by implementing the interface ```com.exasol.adapter.dialects.SqlDialect```.
+You can implement a dialect by implementing the interface `com.exasol.adapter.dialects.SqlDialect`.
 We recommend to look at the following ressources to get started:
 * First have a look at the [SqlDialect interface source code](../virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java). You can start with the comments of the interface and have a look at the methods you can override.
 * Second you can review the source code of one of the [dialect implementations](../virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl) as an inspiration. Ideally you should look at the dialect which is closest to your data source.
@@ -20,44 +20,44 @@ To implement a full dialect for a typical data source you have to run all of the
 ### Setup EXASOL
 * Setup and start an EXASOL database with virtual schemas feature
 * Upload the JDBC drivers of the data source via EXAOperation
-* Manual test: query data from the data source via IMPORT FROM JDBC
+* Manual test: query data from the data source via `IMPORT FROM JDBC`
 
 ### Catalog, Schema & Table Mapping
-* Override the SqlDialect methods for catalog, schema and table mapping
+* Override the `SqlDialect` methods for catalog, schema and table mapping
 * Manual test: create a virtual schema by specifying the catalog and/or schema.
 
 ### Data Type Mapping
 * Testdata: Create a table with all data types and at least one row of data
-* Override the SqlDialect method for data type mapping
+* Override the `SqlDialect` method for data type mapping
 * Automatic test: sys tables show virtual table and columns with correctly mapped type
-* Automatic test: running SELECT on the virtual table returns the expected result
+* Automatic test: running `SELECT` on the virtual table returns the expected result
 
 ### Identifier Case Handling & Quoting
 * Testdata: Create a schema/table/column with mixed case (if supported)
 * Automatic test: sys tables correct
-* Automatic test: SELECT works as expected
+* Automatic test: `SELECT` works as expected
 
 ### Projection Capability
 * Add capability
-* Automatic test: pushed down & correct result (incl. EXPLAIN VIRTUAL). Also test with mixed case columns.
+* Automatic test: pushed down & correct result (incl. `EXPLAIN VIRTUAL`). Also test with mixed case columns.
 
 ### Predicates and Literal Capabilities
-* Add capabilities for supported literals and predicates (e.g. c1='foo')
-* Automatic test: pushed down & correct result (incl. EXPLAIN VIRTUAL) for all predicates & literals
+* Add capabilities for supported literals and predicates (e.g. `c1='foo'`)
+* Automatic test: pushed down & correct result (incl. `EXPLAIN VIRTUAL`) for all predicates & literals
 
 ### Aggregation & Set Function Capabilities
 * Add capabilities for aggregations and aggregation functions
-* Automatic test: pushed down & correct result (incl. EXPLAIN VIRTUAL) for all set functions
+* Automatic test: pushed down & correct result (incl. `EXPLAIN VIRTUAL`) for all set functions
 
 ### Order By / Limit Capabilities
 * Testdata: Create a table with null values and non-null values, to check null collation.
 * Add capabilities for order by and/or limit
-* Automatic test: pushed down & correct result (incl. EXPLAIN VIRTUAL)
-* Automatic test: default null collation, explicit NULLS FIRST/LAST
+* Automatic test: pushed down & correct result (incl. `EXPLAIN VIRTUAL`)
+* Automatic test: default null collation, explicit `NULLS FIRST/LAST`
 
 ### Scalar Function Capabilities
 * Add capabilities for scalar functions
-* Automatic test: pushed down & correct result (incl. EXPLAIN VIRTUAL)
+* Automatic test: pushed down & correct result (incl. `EXPLAIN VIRTUAL`)
 
 ### Views
 * Testdata: Create a simple view, e.g. joining two existing tables
@@ -107,5 +107,5 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 ```
 
 In eclipse (or any other Java IDE) you can then attach remotely to the Java Adapter using the IP of your one node EXASOL environment and the port 8000.
-With suspend=y the Java-process will wait until the debugger connects to the Java UDF.
+With `suspend=y` the Java-process will wait until the debugger connects to the Java UDF.
 

--- a/jdbc-adapter/doc/supported-dialects.md
+++ b/jdbc-adapter/doc/supported-dialects.md
@@ -52,7 +52,7 @@ CREATE VIRTUAL SCHEMA virtual_exasol USING adapter.jdbc_adapter WITH
 
 **Use IMPORT FROM EXA instead of IMPORT FROM JDBC**
 
-EXASOL provides the faster and parallel ```IMPORT FROM EXA``` command for loading data from EXASOL. You can tell the adapter to use this command instead of ```IMPORT FROM JDBC``` by setting the ```IMPORT_FROM_EXA``` property. In this case you have to provide the additional ```EXA_CONNECTION_STRING``` which is the connection string used for the internally used ```IMPORT FROM EXA``` command (it also supports ranges like ```192.168.6.11..14:8563```). Please note, that the ```CONNECTION``` object must still have the jdbc connection string in ```AT```, because the Adapter Script uses a JDBC connection to obtain the metadata when a schema is created or refreshed. For the internally used ```IMPORT FROM EXA``` statement, the address from ```EXA_CONNECTION_STRING``` and the username and password from the connection will be used.
+EXASOL provides the faster and parallel `IMPORT FROM EXA` command for loading data from EXASOL. You can tell the adapter to use this command instead of `IMPORT FROM JDBC` by setting the `IMPORT_FROM_EXA` property. In this case you have to provide the additional `EXA_CONNECTION_STRING` which is the connection string used for the internally used `IMPORT FROM EXA` command (it also supports ranges like `192.168.6.11..14:8563`). Please note, that the `CONNECTION` object must still have the jdbc connection string in `AT`, because the Adapter Script uses a JDBC connection to obtain the metadata when a schema is created or refreshed. For the internally used `IMPORT FROM EXA` statement, the address from `EXA_CONNECTION_STRING` and the username and password from the connection will be used.
 ```sql
 CREATE CONNECTION exasol_conn TO 'jdbc:exa:exasol-host:1234' USER 'user' IDENTIFIED BY 'pwd';
 
@@ -72,14 +72,14 @@ The dialect was tested with the Cloudera Hive JDBC driver available on the [Clou
 When you unpack the JDBC driver archive you will see that there are two variants, JDBC 4.0 and 4.1. We tested with the JDBC 4.1 variant.
 
 You have to specify the following settings when adding the JDBC driver via EXAOperation:
-* Name: ```Hive```
-* Main: ```com.cloudera.hive.jdbc41.HS2Driver```
-* Prefix: ```jdbc:hive2:```
+* Name: `Hive`
+* Main: `com.cloudera.hive.jdbc41.HS2Driver`
+* Prefix: `jdbc:hive2:`
 
 Make sure you upload **all files** of the JDBC driver (over 10 at the time of writing) in EXAOperation **and** to the bucket.
 
 **Adapter script**:
-You have to add all files of the JDBC driver to the classpath using %jar as follows (filenames may vary):
+You have to add all files of the JDBC driver to the classpath using `%jar` as follows (filenames may vary):
 ```sql
 CREATE SCHEMA adapter;
 CREATE  JAVA  ADAPTER SCRIPT jdbc_adapter AS
@@ -112,21 +112,21 @@ CREATE VIRTUAL SCHEMA hive_default USING adapter.jdbc_adapter WITH
 
 ### Connecting To a Kerberos Secured Hadoop:
 
-Connecting to a Kerberos secured Impala or Hive service only differs in one aspect: You have to a ```CONNECTION``` object which contains all the relevant information for the Kerberos authentication. This section describes how Kerberos authentication works and how to create such a ```CONNECTION```.
+Connecting to a Kerberos secured Impala or Hive service only differs in one aspect: You have to a `CONNECTION` object which contains all the relevant information for the Kerberos authentication. This section describes how Kerberos authentication works and how to create such a `CONNECTION`.
 
 #### 0. Understand how it works (optional)
-Both the adapter script and the internally used ```IMPORT FROM JDBC``` statement support Kerberos authentication. They detect, that the connection is a Kerberos connection by a special prefix in the ```IDENTIFIED BY``` field. In such case, the authentication will happen using a Kerberos keytab and Kerberos config file (using the JAAS Java API).
+Both the adapter script and the internally used `IMPORT FROM JDBC` statement support Kerberos authentication. They detect, that the connection is a Kerberos connection by a special prefix in the `IDENTIFIED BY` field. In such case, the authentication will happen using a Kerberos keytab and Kerberos config file (using the JAAS Java API).
 
-The ```CONNECTION``` object stores all relevant information and files in its fields:
-* The ```TO``` field contains the JDBC connection string
-* The ```USER``` field contains the Kerberos principal
-* The ```IDENTIFIED BY``` field contains the Kerberos configuration file and keytab file (base64 encoded) along with an internal prefix ```ExaAuthType=Kerberos;``` to identify the CONNECTION as a Kerberos CONNECTION.
+The `CONNECTION` object stores all relevant information and files in its fields:
+* The `TO` field contains the JDBC connection string
+* The `USER` field contains the Kerberos principal
+* The `IDENTIFIED BY` field contains the Kerberos configuration file and keytab file (base64 encoded) along with an internal prefix `ExaAuthType=Kerberos;` to identify the `CONNECTION` as a Kerberos `CONNECTION`.
 
 #### 1. Generate the CREATE CONNECTION statement
-In order to simplify the creation of Kerberos CONNECTION objects, the [create_kerberos_conn.py](https://github.com/EXASOL/hadoop-etl-udfs/blob/master/tools/create_kerberos_conn.py) Python script has been provided. The script requires 5 arguments:
-* CONNECTION name (arbitrary name for the new CONNECTION)
+In order to simplify the creation of Kerberos `CONNECTION` objects, the [`create_kerberos_conn.py`](https://github.com/EXASOL/hadoop-etl-udfs/blob/master/tools/create_kerberos_conn.py) Python script has been provided. The script requires 5 arguments:
+* `CONNECTION` name (arbitrary name for the new `CONNECTION`)
 * Kerberos principal for Hadoop (i.e., Hadoop user)
-* Kerberos configuration file path (e.g., krb5.conf)
+* Kerberos configuration file path (e.g., `krb5.conf`)
 * Kerberos keytab file path, which contains keys for the Kerberos principal
 * JDBC connection string
 
@@ -141,7 +141,7 @@ CREATE CONNECTION krb_conn TO 'jdbc:hive2://hive-host.example.com:10000;AuthMech
 ```
 
 #### 2. Create the CONNECTION
-You have to execute the generated CREATE CONNECTION statement directly in EXASOL to actually create the Kerberos CONNECTION object. For more detailed information about the script, use the help option:
+You have to execute the generated `CREATE CONNECTION` statement directly in EXASOL to actually create the Kerberos `CONNECTION` object. For more detailed information about the script, use the help option:
 ```
 python tools/create_kerberos_conn.py -h
 ```
@@ -162,9 +162,9 @@ The Impala dialect is similar to the Hive dialect in most aspects. For this reas
 **JDBC driver:**
 
 You have to specify the following settings when adding the JDBC driver via EXAOperation:
-* Name: ```Hive```
-* Main: ```com.cloudera.impala.jdbc41.Driver```
-* Prefix: ```jdbc:impala:```
+* Name: `Hive`
+* Main: `com.cloudera.impala.jdbc41.Driver`
+* Prefix: `jdbc:impala:`
 
 Make sure you upload **all files** of the JDBC driver (over 10 at the time of writing) in EXAOperation and to the bucket.
 
@@ -207,11 +207,11 @@ Connecting to a Kerberos secured Impala works similar as for Hive and is describ
 
 ## DB2
 
-DB2 was tested with the IBM DB2 JCC Drivers that come with DB2 LUW V10.1 and V11. As these drivers didn't have any major changes in the past years any DB2 driver should work (back to V9.1). The driver comes with 2 different implementations db2jcc.jar and db2jcc4.jar. All tests were made with the db2jcc4.jar.
+DB2 was tested with the IBM DB2 JCC Drivers that come with DB2 LUW V10.1 and V11. As these drivers didn't have any major changes in the past years any DB2 driver should work (back to V9.1). The driver comes with 2 different implementations `db2jcc.jar` and `db2jcc4.jar`. All tests were made with the `db2jcc4.jar`.
 
 Additionally there are 2 files for the DB2 Driver.
-* db2jcc_license_cu.jar - License File for DB2 on Linux Unix and Windows
-* db2jcc_license_cisuz.jar - License File for DB2 on zOS (Mainframe)
+* `db2jcc_license_cu.jar` - License File for DB2 on Linux Unix and Windows
+* `db2jcc_license_cisuz.jar` - License File for DB2 on zOS (Mainframe)
 
 Make sure that you upload the necessary license file for the target platform you want to connect to. 
 
@@ -219,23 +219,23 @@ Make sure that you upload the necessary license file for the target platform you
 The db2 dialect handles some casts in regards of time data types and functions.
 
 Casting of Data Types
-* TIMESTAMP and TIMESTAMP(x) will be cast to VARCHAR to not lose precision.
-* VARCHAR and CHAR for bit data will be cast to a hex string with double the original size
-* TIME will be cast to VARCHAR(8)
-* XML will be cast to VARCHAR(DB2_MAX_LENGTH)
-* BLOB is not supported
+* `TIMESTAMP` and `TIMESTAMP(x)` will be cast to `VARCHAR` to not lose precision.
+* `VARCHAR` and `CHAR` for bit data will be cast to a hex string with double the original size
+* `TIME` will be cast to `VARCHAR(8)`
+* `XML` will be cast to `VARCHAR(DB2_MAX_LENGTH)`
+* `BLOB` is not supported
 
 Casting of Functions
-* LIMIT will replaced by FETCH FIRST x ROWS ONLY
-* OFFESET is currently not supported as only DB2 V11 support this nativly
-* ADD_DAYS, ADD_WEEKS ... will be replaced by COLUMN + DAYS, COLUMN + ....
+* `LIMIT` will replaced by `FETCH FIRST x ROWS ONLY`
+* `OFFSET` is currently not supported as only DB2 V11 support this nativly
+* `ADD_DAYS`, `ADD_WEEKS` ... will be replaced by `COLUMN + DAYS`, `COLUMN + ....`
 
 
 **JDBC driver:**
 You have to specify the following settings when adding the JDBC driver via EXAOperation:
-* Name: ```DB2```
-* Main: ```com.ibm.db2.jcc.DB2Driver```
-* Prefix: ```jdbc:db2:```
+* Name: `DB2`
+* Main: `com.ibm.db2.jcc.DB2Driver`
+* Prefix: `jdbc:db2:`
 
 **Adapter script**
 ```sql
@@ -268,7 +268,7 @@ create  virtual schema db2 using adapter.jdbc_adapter with
 ;
 ```
 
-```<schemaname>``` has to be replaced by the actual db2 schema you want to connect to.
+`<schemaname>` has to be replaced by the actual db2 schema you want to connect to.
 
 **Running the DB2 integration tests**
 A how to has been included in the [setup sql file](../integration-test-data/db2-testdata.sql)
@@ -335,7 +335,7 @@ Exasol provides the `IMPORT FROM ORA` command for loading data from Oracle. It i
 This behaviour is toggled by the Boolean `IMPORT_FROM_ORA` variable. Note that a JDBC connection to Oracle is still required to fetch metadata. In addition, a "direct" connection to the Oracle database is needed.
 
 **Deploy the Oracle Instant Client**:
-To be able to communicate with Oracle, you first need to supply Exasol with the Oracle Instant Client, which can be obtained [directly from Oracle](http://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html). Open EXAoperation, visit Software -> "Upload Oracle Instant Client" and select the downloaded package. The latest version of Oracle Instant Client we tested is "instantclient-basic-linux.x64-12.1.0.2.0".
+To be able to communicate with Oracle, you first need to supply Exasol with the Oracle Instant Client, which can be obtained [directly from Oracle](http://www.oracle.com/technetwork/database/database-technologies/instant-client/overview/index.html). Open EXAoperation, visit Software -> "Upload Oracle Instant Client" and select the downloaded package. The latest version of Oracle Instant Client we tested is `instantclient-basic-linux.x64-12.1.0.2.0`.
 
 **Create an Oracle Connection**:
 Having deployed the Oracle Instant Client, a connection to your Oracle database can be set up.
@@ -372,10 +372,10 @@ CREATE VIRTUAL SCHEMA virt_import_oracle USING adapter.jdbc_oracle WITH
 
 **JDBC driver:**
 You have to specify the following settings when adding the JDBC driver via EXAOperation:
-* Name: ```TERADATA```
-* Main: ```com.teradata.jdbc.TeraDriver```
-* Prefix: ```jdbc:teradata:```
-* Files: terajdbc4.jar, tdgssconfig.jar
+* Name: `TERADATA`
+* Main: `com.teradata.jdbc.TeraDriver`
+* Prefix: `jdbc:teradata:`
+* Files: `terajdbc4.jar`, `tdgssconfig.jar`
 
 Please also upload the jar files to a bucket for the adapter script.
 
@@ -413,10 +413,10 @@ WITH
 **JDBC driver:**
 
 You have to specify the following settings when adding the JDBC driver via EXAOperation:
-* Name: ```REDSHIFT```
-* Main: ```com.amazon.redshift.jdbc.Driver```
-* Prefix: ```jdbc:redshift:```
-* Files: RedshiftJDBC42-1.2.1.1001.jar
+* Name: `REDSHIFT`
+* Main: `com.amazon.redshift.jdbc.Driver`
+* Prefix: `jdbc:redshift:`
+* Files: `RedshiftJDBC42-1.2.1.1001.jar`
 
 Please also upload the driver jar into a bucket for the adapter script.
 
@@ -455,8 +455,8 @@ CREATE VIRTUAL SCHEMA redshift_tickit
 
 **JDBC driver:**
 The Sql Server Dialect was tested with the jdts 1.3.1 JDBC driver and Sql Server 2014.
-As the jdts driver is already preinstalled for the IMPORT command itself you only need
-to upload the jdts.jar to a bucket for the adapter script.
+As the jdts driver is already preinstalled for the `IMPORT` command itself you only need
+to upload the `jdts.jar` to a bucket for the adapter script.
 
 **Adapter script**
 ```sql


### PR DESCRIPTION
Here are some follow-up changes to documentation as discussed in #27.

With this PR the syntax used to highlight inline code is consistent in all Markdown files. Often instead of a single backtick (\`) three backticks were used which conflicts with [GitHub's recommendation](https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code). Also, using three backticks for inline code is distracting (read: it conflicts with my personal taste :see_no_evil:). 