### PR TITLE
Fix for keyword quoting (#40)

### DIFF
--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
@@ -308,15 +308,8 @@ public class DB2SqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        // Quoted identifiers can contain any unicode char except dot (.).
-        // This is a simplified rule, which might cause that some identifiers are quoted
-        // although not needed
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/ExasolSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/ExasolSqlDialect.java
@@ -105,15 +105,8 @@ public class ExasolSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        // Quoted identifiers can contain any unicode char except dot (.).
-        // This is a simplified rule, which might cause that some identifiers are quoted
-        // although not needed
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
@@ -415,12 +415,8 @@ public class OracleSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -350,12 +350,8 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/RedshiftSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/RedshiftSqlDialect.java
@@ -266,12 +266,8 @@ public class RedshiftSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
@@ -467,12 +467,8 @@ public class SqlServerSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SybaseSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SybaseSqlDialect.java
@@ -475,12 +475,8 @@ public class SybaseSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/TeradataSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/TeradataSqlDialect.java
@@ -279,12 +279,8 @@ public class TeradataSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/CustomSqlGenerationVisitorTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/CustomSqlGenerationVisitorTest.java
@@ -28,8 +28,8 @@ public class CustomSqlGenerationVisitorTest {
     public void testSqlGenerator() throws AdapterException {
         SqlNode node = getTestSqlNode();
         String schemaName = "SCHEMA";
-        String expectedSql = "SELECT NOT_CUSTOM (NOT_CUSTOM (C1)) FROM " + schemaName
-                + ".TEST";
+        String expectedSql = "SELECT NOT_CUSTOM (NOT_CUSTOM (\"C1\")) FROM \"" + schemaName
+                + "\".\"TEST\"";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName,
                 false);
         SqlDialectContext dialectContext = new SqlDialectContext(Mockito.mock(SchemaAdapterNotes.class));

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectTest.java
@@ -18,9 +18,9 @@ public class ExasolSqlDialectTest {
     public void testApplyQuoteIfNeeded() {
         ExasolSqlDialect dialect = new ExasolSqlDialect(DialectTestData.getExasolDialectContext());
         // Regular Identifiers
-        assertEquals("A1", dialect.applyQuoteIfNeeded("A1"));
-        assertEquals("A_1", dialect.applyQuoteIfNeeded("A_1"));
-        assertEquals("A", dialect.applyQuoteIfNeeded("A"));
+        assertEquals("\"A1\"", dialect.applyQuoteIfNeeded("A1"));
+        assertEquals("\"A_1\"", dialect.applyQuoteIfNeeded("A_1"));
+        assertEquals("\"A\"", dialect.applyQuoteIfNeeded("A"));
         
         // Irregular Identifiers
         assertEquals("\"A_a_1\"", dialect.applyQuoteIfNeeded("A_a_1"));
@@ -41,11 +41,11 @@ public class ExasolSqlDialectTest {
     public void testSqlGenerator() throws AdapterException {
         SqlNode node = DialectTestData.getTestSqlNode();
         String schemaName = "SCHEMA";
-        String expectedSql = "SELECT USER_ID, COUNT(URL) FROM " + schemaName + ".CLICKS" +
-        " WHERE 1 < USER_ID" +
-        " GROUP BY USER_ID" +
-        " HAVING 1 < COUNT(URL)" +
-        " ORDER BY USER_ID" +
+        String expectedSql = "SELECT \"USER_ID\", COUNT(\"URL\") FROM \"" + schemaName + "\".\"CLICKS\"" +
+        " WHERE 1 < \"USER_ID\"" +
+        " GROUP BY \"USER_ID\"" +
+        " HAVING 1 < COUNT(\"URL\")" +
+        " ORDER BY \"USER_ID\"" +
         " LIMIT 10";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
         SqlDialect dialect = new ExasolSqlDialect(DialectTestData.getExasolDialectContext());

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectTest.java
@@ -23,12 +23,12 @@ public class OracleSqlDialectTest {
         SqlNode node = DialectTestData.getTestSqlNode();
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT LIMIT_SUBSELECT.* FROM ( " +
-                "  SELECT USER_ID, COUNT(URL) " +
-                "    FROM SCHEMA.CLICKS" +
-                "    WHERE 1 < USER_ID" +
-                "    GROUP BY USER_ID" +
-                "    HAVING 1 < COUNT(URL)" +
-                "    ORDER BY USER_ID " +
+                "  SELECT \"USER_ID\", COUNT(\"URL\") " +
+                "    FROM \"SCHEMA\".\"CLICKS\"" +
+                "    WHERE 1 < \"USER_ID\"" +
+                "    GROUP BY \"USER_ID\"" +
+                "    HAVING 1 < COUNT(\"URL\")" +
+                "    ORDER BY \"USER_ID\" " +
                 ") LIMIT_SUBSELECT WHERE ROWNUM <= 10" ;
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
         SqlDialectContext dialectContext = new SqlDialectContext(Mockito.mock(SchemaAdapterNotes.class));
@@ -45,12 +45,12 @@ public class OracleSqlDialectTest {
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT c0, c1 FROM (" +
                 "  SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( " +
-                "    SELECT USER_ID AS c0, COUNT(URL) AS c1 " +
-                "      FROM SCHEMA.CLICKS" +
-                "      WHERE 1 < USER_ID" +
-                "      GROUP BY USER_ID" +
-                "      HAVING 1 < COUNT(URL)" +
-                "      ORDER BY USER_ID" +
+                "    SELECT \"USER_ID\" AS c0, COUNT(\"URL\") AS c1 " +
+                "      FROM \"SCHEMA\".\"CLICKS\"" +
+                "      WHERE 1 < \"USER_ID\"" +
+                "      GROUP BY \"USER_ID\"" +
+                "      HAVING 1 < COUNT(\"URL\")" +
+                "      ORDER BY \"USER_ID\"" +
                 "  ) LIMIT_SUBSELECT WHERE ROWNUM <= 15 " +
                 ") WHERE ROWNUM_SUB > 5";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
@@ -69,12 +69,12 @@ public class OracleSqlDialectTest {
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT c0, c1 FROM (" +
                 "  SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( " +
-                "    SELECT USER_ID AS c0, URL AS c1 " +
-                "      FROM SCHEMA.CLICKS" +
-                "      WHERE 1 < USER_ID" +
-                "      GROUP BY USER_ID" +
-                "      HAVING 1 < COUNT(URL)" +
-                "      ORDER BY USER_ID" +
+                "    SELECT \"USER_ID\" AS c0, \"URL\" AS c1 " +
+                "      FROM \"SCHEMA\".\"CLICKS\"" +
+                "      WHERE 1 < \"USER_ID\"" +
+                "      GROUP BY \"USER_ID\"" +
+                "      HAVING 1 < COUNT(\"URL\")" +
+                "      ORDER BY \"USER_ID\"" +
                 "  ) LIMIT_SUBSELECT WHERE ROWNUM <= 15 " +
                 ") WHERE ROWNUM_SUB > 5";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);


### PR DESCRIPTION
The fix is to quote all identifiers. This doesn't do any harm and fixes the problem with unquoted keywords.