### PR TITLE
Fix for keyword quoting problem (#40)

### DIFF
--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/DB2SqlDialect.java
@@ -308,15 +308,8 @@ public class DB2SqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        // Quoted identifiers can contain any unicode char except dot (.).
-        // This is a simplified rule, which might cause that some identifiers are quoted
-        // although not needed
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/ExasolSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/ExasolSqlDialect.java
@@ -105,15 +105,8 @@ public class ExasolSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        // Quoted identifiers can contain any unicode char except dot (.).
-        // This is a simplified rule, which might cause that some identifiers are quoted
-        // although not needed
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
@@ -415,12 +415,8 @@ public class OracleSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -350,12 +350,8 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/RedshiftSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/RedshiftSqlDialect.java
@@ -266,12 +266,8 @@ public class RedshiftSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
@@ -467,12 +467,8 @@ public class SqlServerSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SybaseSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SybaseSqlDialect.java
@@ -475,12 +475,8 @@ public class SybaseSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/TeradataSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/TeradataSqlDialect.java
@@ -279,12 +279,8 @@ public class TeradataSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuoteIfNeeded(final String identifier) {
-        final boolean isSimpleIdentifier = identifier.matches("^[A-Z][0-9A-Z_]*");
-        if (isSimpleIdentifier) {
-            return identifier;
-        } else {
-            return applyQuote(identifier);
-        }
+        // This is a simplified rule, which quotes all identifiers although not needed
+        return applyQuote(identifier);
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/CustomSqlGenerationVisitorTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/CustomSqlGenerationVisitorTest.java
@@ -28,8 +28,8 @@ public class CustomSqlGenerationVisitorTest {
     public void testSqlGenerator() throws AdapterException {
         SqlNode node = getTestSqlNode();
         String schemaName = "SCHEMA";
-        String expectedSql = "SELECT NOT_CUSTOM (NOT_CUSTOM (C1)) FROM " + schemaName
-                + ".TEST";
+        String expectedSql = "SELECT NOT_CUSTOM (NOT_CUSTOM (\"C1\")) FROM \"" + schemaName
+                + "\".\"TEST\"";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName,
                 false);
         SqlDialectContext dialectContext = new SqlDialectContext(Mockito.mock(SchemaAdapterNotes.class));

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/DB2SqlDialectIT.java
@@ -40,7 +40,7 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new BigDecimal("9.99"), new BigDecimal("7.25"));
         matchSingleRowExplain(query,
-                "SELECT PRICE, PROMOPRICE FROM " + DB2_SCHEMA + ".PRODUCT WHERE PID = '100-100-01'");
+                "SELECT \"PRICE\", \"PROMOPRICE\" FROM \"" + DB2_SCHEMA + "\".\"PRODUCT\" WHERE \"PID\" = '100-100-01'");
     }
 
     @Test
@@ -49,7 +49,7 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new BigDecimal("9.99"), new BigDecimal("7.25"));
         matchSingleRowExplain(query,
-                "SELECT PRICE, PROMOPRICE FROM " + DB2_SCHEMA + ".PRODUCT FETCH FIRST 1 ROWS ONLY");
+                "SELECT \"PRICE\", \"PROMOPRICE\" FROM \"" + DB2_SCHEMA + "\".\"PRODUCT\" FETCH FIRST 1 ROWS ONLY");
     }
 
     @Test
@@ -58,8 +58,8 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
                 + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, "2020-01-01-00.00.00.123456789123", "12.05.11");
-        matchSingleRowExplain(query, "SELECT VARCHAR(DETAIL_TIMESTAMP), VARCHAR(UHRZEIT) FROM " + DB2_SCHEMA
-                + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+        matchSingleRowExplain(query, "SELECT VARCHAR(\"DETAIL_TIMESTAMP\"), VARCHAR(\"UHRZEIT\") FROM \"" + DB2_SCHEMA
+                + "\".\"Additional_Datatypes\" WHERE \"DETAIL_TIMESTAMP\" = '2020-01-01-00.00.00.123456789123'");
 
     }
 
@@ -70,8 +70,8 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
         final ResultSet result = executeQuery(query);
         matchNextRow(result, "30303031",
                 "41414242202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020");
-        matchSingleRowExplain(query, "SELECT HEX(BIDATAVARCHAR), HEX(BIDATACHAR) FROM " + DB2_SCHEMA
-                + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+        matchSingleRowExplain(query, "SELECT HEX(\"BIDATAVARCHAR\"), HEX(\"BIDATACHAR\") FROM \"" + DB2_SCHEMA
+                + "\".\"Additional_Datatypes\" WHERE \"DETAIL_TIMESTAMP\" = '2020-01-01-00.00.00.123456789123'");
 
     }
 
@@ -81,8 +81,8 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
                 + ".\"Additional_Datatypes\"  WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, "CHAR 茶");
-        matchSingleRowExplain(query, "SELECT UNICODECOL FROM " + DB2_SCHEMA
-                + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+        matchSingleRowExplain(query, "SELECT \"UNICODECOL\" FROM \"" + DB2_SCHEMA
+                + "\".\"Additional_Datatypes\" WHERE \"DETAIL_TIMESTAMP\" = '2020-01-01-00.00.00.123456789123'");
 
     }
 
@@ -94,9 +94,9 @@ public class DB2SqlDialectIT extends AbstractIntegrationTest {
         final ResultSet result = executeQuery(query);
         matchNextRow(result, "2020-01-03-00.00.00.123456789123", "2018-01-01-00.00.00.123456789123", "CHAR");
         matchSingleRowExplain(query,
-                "SELECT VARCHAR(DETAIL_TIMESTAMP + 2 DAYS), VARCHAR(DETAIL_TIMESTAMP + -2 YEARS), SUBSTR(UNICODECOL, 1, 4) FROM "
+                "SELECT VARCHAR(\"DETAIL_TIMESTAMP\" + 2 DAYS), VARCHAR(\"DETAIL_TIMESTAMP\" + -2 YEARS), SUBSTR(\"UNICODECOL\", 1, 4) FROM \""
                         + DB2_SCHEMA
-                        + ".\"Additional_Datatypes\" WHERE DETAIL_TIMESTAMP = '2020-01-01-00.00.00.123456789123'");
+                        + "\".\"Additional_Datatypes\" WHERE \"DETAIL_TIMESTAMP\" = '2020-01-01-00.00.00.123456789123'");
     }
 
     private static void createDB2JDBCAdapter() throws SQLException, FileNotFoundException {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -159,31 +159,31 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         String query = "SELECT GROUP_CONCAT(A) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
         matchLastRow(result, "1,1,2,2,3,3");
-        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(A) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES", IS_LOCAL);
+        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(\"A\") FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"", IS_LOCAL);
         query = "SELECT GROUP_CONCAT(DISTINCT A) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchLastRow(result, "1,2,3");
-        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(DISTINCT A) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(DISTINCT \"A\") FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT GROUP_CONCAT(A ORDER BY C) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchLastRow(result, "1,2,3,1,2,3");
-        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(A ORDER BY C) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(\"A\" ORDER BY \"C\") FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT GROUP_CONCAT(A ORDER BY C DESC) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchLastRow(result, "3,2,1,3,2,1");
-        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(A ORDER BY C DESC) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(\"A\" ORDER BY \"C\" DESC) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT GROUP_CONCAT(A ORDER BY C DESC NULLS LAST) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchLastRow(result, "3,2,1,3,2,1");
         matchSingleRowExplain(query,
-                "SELECT GROUP_CONCAT(A ORDER BY C DESC NULLS LAST) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES", IS_LOCAL);
+                "SELECT GROUP_CONCAT(\"A\" ORDER BY \"C\" DESC NULLS LAST) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"", IS_LOCAL);
         query = "SELECT GROUP_CONCAT(A SEPARATOR ';'||' ')  FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchLastRow(result, "1; 1; 2; 2; 3; 3");
-        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(A SEPARATOR '; ') FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT GROUP_CONCAT(\"A\" SEPARATOR '; ') FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
     }
 
@@ -192,11 +192,11 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         String query = "SELECT EXTRACT(MONTH FROM C9) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         ResultSet result = executeQuery(query);
         matchLastRow(result, (short) 8);
-        matchSingleRowExplain(query, "SELECT EXTRACT(MONTH FROM C9) FROM " + TEST_SCHEMA + ".ALL_EXA_TYPES", IS_LOCAL);
+        matchSingleRowExplain(query, "SELECT EXTRACT(MONTH FROM \"C9\") FROM \"" + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"", IS_LOCAL);
         query = "SELECT EXTRACT(MONTH FROM C12) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchLastRow(result, (short) 6);
-        matchSingleRowExplain(query, "SELECT EXTRACT(MONTH FROM C12) FROM " + TEST_SCHEMA + ".ALL_EXA_TYPES", IS_LOCAL);
+        matchSingleRowExplain(query, "SELECT EXTRACT(MONTH FROM \"C12\") FROM \"" + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"", IS_LOCAL);
     }
 
     @Test
@@ -204,68 +204,68 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         String query = "SELECT CAST(A AS CHAR(15)) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
         matchNextRow(result, "1              ");
-        matchSingleRowExplain(query, "SELECT CAST(A AS CHAR(15) UTF8) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT CAST(\"A\" AS CHAR(15) UTF8) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(A > 0 AS VARCHAR(15)) AS BOOLEAN) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchNextRow(result, true);
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(0 < A AS VARCHAR(15) UTF8) AS BOOLEAN) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+                "SELECT CAST(CAST(0 < \"A\" AS VARCHAR(15) UTF8) AS BOOLEAN) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(C9 AS VARCHAR(30)) AS DATE) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, getSqlDate(2016, 8, 1));
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C9 AS VARCHAR(30) UTF8) AS DATE) FROM " + TEST_SCHEMA + ".ALL_EXA_TYPES", IS_LOCAL);
+                "SELECT CAST(CAST(\"C9\" AS VARCHAR(30) UTF8) AS DATE) FROM \"" + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"", IS_LOCAL);
         query = "SELECT CAST(CAST(A AS VARCHAR(15)) AS DECIMAL(8, 1)) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchNextRow(result, new BigDecimal("1.0"));
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(A AS VARCHAR(15) UTF8) AS DECIMAL(8, 1)) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+                "SELECT CAST(CAST(\"A\" AS VARCHAR(15) UTF8) AS DECIMAL(8, 1)) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(C AS VARCHAR(15)) AS DOUBLE) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchNextRow(result, 1.1d);
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C AS VARCHAR(15) UTF8) AS DOUBLE) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES", IS_LOCAL);
+                "SELECT CAST(CAST(\"C\" AS VARCHAR(15) UTF8) AS DOUBLE) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"", IS_LOCAL);
         query = "SELECT CAST(CAST(C14 AS VARCHAR(100)) AS GEOMETRY(5)) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, "POINT (2 5)");
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C14 AS VARCHAR(100) UTF8) AS GEOMETRY(5)) FROM " + TEST_SCHEMA + ".ALL_EXA_TYPES",
+                "SELECT CAST(CAST(\"C14\" AS VARCHAR(100) UTF8) AS GEOMETRY(5)) FROM \"" + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(C13 AS VARCHAR(100)) AS INTERVAL DAY (5) TO SECOND (2)) FROM " + VIRTUAL_SCHEMA
                 + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, "+00003 12:50:10.12");
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C13 AS VARCHAR(100) UTF8) AS INTERVAL DAY (5) TO SECOND (2)) FROM " + TEST_SCHEMA
-                        + ".ALL_EXA_TYPES",
+                "SELECT CAST(CAST(\"C13\" AS VARCHAR(100) UTF8) AS INTERVAL DAY (5) TO SECOND (2)) FROM \"" + TEST_SCHEMA
+                        + "\".\"ALL_EXA_TYPES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(C12 AS VARCHAR(100)) AS INTERVAL YEAR (5) TO MONTH) FROM " + VIRTUAL_SCHEMA
                 + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, "+00004-06");
-        matchSingleRowExplain(query, "SELECT CAST(CAST(C12 AS VARCHAR(100) UTF8) AS INTERVAL YEAR (5) TO MONTH) FROM "
-                + TEST_SCHEMA + ".ALL_EXA_TYPES", IS_LOCAL);
+        matchSingleRowExplain(query, "SELECT CAST(CAST(\"C12\" AS VARCHAR(100) UTF8) AS INTERVAL YEAR (5) TO MONTH) FROM \""
+                + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"", IS_LOCAL);
         query = "SELECT CAST(CAST(C10 AS VARCHAR(100)) AS TIMESTAMP) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, getSqlTimestamp(2016, 8, 1, 0, 0, 1, 0));
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C10 AS VARCHAR(100) UTF8) AS TIMESTAMP) FROM " + TEST_SCHEMA + ".ALL_EXA_TYPES",
+                "SELECT CAST(CAST(\"C10\" AS VARCHAR(100) UTF8) AS TIMESTAMP) FROM \"" + TEST_SCHEMA + "\".\"ALL_EXA_TYPES\"",
                 IS_LOCAL);
         query = "SELECT CAST(CAST(C11 AS VARCHAR(100)) AS TIMESTAMP WITH LOCAL TIME ZONE) FROM " + VIRTUAL_SCHEMA
                 + ".ALL_EXA_TYPES";
         result = executeQuery(query);
         matchNextRow(result, getSqlTimestamp(2016, 8, 1, 0, 0, 2, 0));
         matchSingleRowExplain(query,
-                "SELECT CAST(CAST(C11 AS VARCHAR(100) UTF8) AS TIMESTAMP WITH LOCAL TIME ZONE) FROM " + TEST_SCHEMA
-                        + ".ALL_EXA_TYPES",
+                "SELECT CAST(CAST(\"C11\" AS VARCHAR(100) UTF8) AS TIMESTAMP WITH LOCAL TIME ZONE) FROM \"" + TEST_SCHEMA
+                        + "\".\"ALL_EXA_TYPES\"",
                 IS_LOCAL);
         query = "SELECT CAST(A AS VARCHAR(15)) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchNextRow(result, "1");
-        matchSingleRowExplain(query, "SELECT CAST(A AS VARCHAR(15) UTF8) FROM " + TEST_SCHEMA + ".SIMPLE_VALUES",
+        matchSingleRowExplain(query, "SELECT CAST(\"A\" AS VARCHAR(15) UTF8) FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"",
                 IS_LOCAL);
     }
 

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -275,13 +275,13 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
                 + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
         matchNextRow(result, "YES");
-        matchSingleRowExplain(query, "SELECT CASE A WHEN 1 THEN 'YES' WHEN 2 THEN 'PERHAPS' ELSE 'NO' END FROM "
-                + TEST_SCHEMA + ".SIMPLE_VALUES", IS_LOCAL);
+        matchSingleRowExplain(query, "SELECT CASE \"A\" WHEN 1 THEN 'YES' WHEN 2 THEN 'PERHAPS' ELSE 'NO' END FROM \""
+                + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"", IS_LOCAL);
         query = "SELECT CASE WHEN A > 1 THEN 'YES' ELSE 'NO' END FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         result = executeQuery(query);
         matchNextRow(result, "NO");
         matchSingleRowExplain(query,
-                "SELECT CASE WHEN 1 < A THEN 'YES' ELSE 'NO' END FROM " + TEST_SCHEMA + ".SIMPLE_VALUES", IS_LOCAL);
+                "SELECT CASE WHEN 1 < \"A\" THEN 'YES' ELSE 'NO' END FROM \"" + TEST_SCHEMA + "\".\"SIMPLE_VALUES\"", IS_LOCAL);
     }
 
     /**

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectTest.java
@@ -18,9 +18,9 @@ public class ExasolSqlDialectTest {
     public void testApplyQuoteIfNeeded() {
         ExasolSqlDialect dialect = new ExasolSqlDialect(DialectTestData.getExasolDialectContext());
         // Regular Identifiers
-        assertEquals("A1", dialect.applyQuoteIfNeeded("A1"));
-        assertEquals("A_1", dialect.applyQuoteIfNeeded("A_1"));
-        assertEquals("A", dialect.applyQuoteIfNeeded("A"));
+        assertEquals("\"A1\"", dialect.applyQuoteIfNeeded("A1"));
+        assertEquals("\"A_1\"", dialect.applyQuoteIfNeeded("A_1"));
+        assertEquals("\"A\"", dialect.applyQuoteIfNeeded("A"));
         
         // Irregular Identifiers
         assertEquals("\"A_a_1\"", dialect.applyQuoteIfNeeded("A_a_1"));
@@ -41,11 +41,11 @@ public class ExasolSqlDialectTest {
     public void testSqlGenerator() throws AdapterException {
         SqlNode node = DialectTestData.getTestSqlNode();
         String schemaName = "SCHEMA";
-        String expectedSql = "SELECT USER_ID, COUNT(URL) FROM " + schemaName + ".CLICKS" +
-        " WHERE 1 < USER_ID" +
-        " GROUP BY USER_ID" +
-        " HAVING 1 < COUNT(URL)" +
-        " ORDER BY USER_ID" +
+        String expectedSql = "SELECT \"USER_ID\", COUNT(\"URL\") FROM \"" + schemaName + "\".\"CLICKS\"" +
+        " WHERE 1 < \"USER_ID\"" +
+        " GROUP BY \"USER_ID\"" +
+        " HAVING 1 < COUNT(\"URL\")" +
+        " ORDER BY \"USER_ID\"" +
         " LIMIT 10";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
         SqlDialect dialect = new ExasolSqlDialect(DialectTestData.getExasolDialectContext());

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectIT.java
@@ -144,7 +144,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRowDecimal(result, "12346.12345");
             matchNextRowDecimal(result, "12356.12345");
         }
-        runMatchSingleRowExplain(query, "SELECT CAST((C7 + 1) AS FLOAT) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT CAST((\"C7\" + 1) AS FLOAT) FROM \"" + ORA_TABLE + "\"");
     }
 
     @Test
@@ -153,7 +153,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "12355.12345");
         }
-        matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " WHERE 12346 < C7");
+        matchSingleRowExplain(query, "SELECT \"C7\" FROM \"" + ORA_TABLE + "\" WHERE 12346 < \"C7\"");
     }
 
     @Test
@@ -162,7 +162,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRowDecimal(result, "12345.12345");
         }
-        runMatchSingleRowExplain(query, "SELECT CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT CAST(MIN(\"C7\") AS FLOAT) FROM \"" + ORA_TABLE + "\"");
     }
 
     @Test
@@ -173,7 +173,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRowDecimal(result, "1234567890.123456789", "12355.12345");
         }
         runMatchSingleRowExplain(query,
-                "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY C5");
+                "SELECT TO_CHAR(\"C5\"), CAST(MIN(\"C7\") AS FLOAT) FROM \"" + ORA_TABLE + "\" GROUP BY \"C5\"");
     }
 
     @Test
@@ -184,7 +184,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRowDecimal(result, "1234567891.123456789", "12355.12345");
         }
         runMatchSingleRowExplain(query,
-                "SELECT CAST((C5 + 1) AS FLOAT), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY (C5 + 1)");
+                "SELECT CAST((\"C5\" + 1) AS FLOAT), CAST(MIN(\"C7\") AS FLOAT) FROM \"" + ORA_TABLE + "\" GROUP BY (\"C5\" + 1)");
     }
 
     @Test
@@ -195,8 +195,8 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
                     "12345.12345");
             matchNextRowDecimal(result, "123456789012345678901234567890123456", "1234567890.123456789", "12355.12345");
         }
-        runMatchSingleRowExplain(query, "SELECT C_NUMBER36, TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE
-                + " GROUP BY C5, C_NUMBER36 ORDER BY C5 DESC");
+        runMatchSingleRowExplain(query, "SELECT \"C\"_NUMBER36, TO_CHAR(\"C5\"), CAST(MIN(\"C7\") AS FLOAT) FROM \"" + ORA_TABLE
+                + "\" GROUP BY \"C5\", \"C_NUMBER36\" ORDER BY \"C5\" DESC");
     }
 
     @Test
@@ -206,7 +206,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRowDecimal(result, "1234567890.123456789", "12355.12345");
         }
         runMatchSingleRowExplain(query,
-                "SELECT TO_CHAR(C5), CAST(MIN(C7) AS FLOAT) FROM " + ORA_TABLE + " GROUP BY C5 HAVING 12350 < MIN(C7)");
+                "SELECT TO_CHAR(\"C5\"), CAST(MIN(\"C7\") AS FLOAT) FROM \"" + ORA_TABLE + "\" GROUP BY \"C5\" HAVING 12350 < MIN(\"C7\")");
     }
 
     @Test
@@ -216,7 +216,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRow(result, "aaaaaaaaaaaaaaaaaaaa                              ");
             matchNextRow(result, (Object) null);
         }
-        runMatchSingleRowExplain(query, "SELECT C1 FROM " + ORA_TABLE + " ORDER BY C1 DESC NULLS LAST");
+        runMatchSingleRowExplain(query, "SELECT \"C1\" FROM \"" + ORA_TABLE + "\" ORDER BY \"C1\" DESC NULLS LAST");
     }
 
     @Test
@@ -226,7 +226,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRow(result, "12355.12345");
             matchNextRow(result, "12345.12345");
         }
-        matchSingleRowExplain(query, "SELECT C7 FROM " + ORA_TABLE + " ORDER BY ABS(C7) DESC");
+        matchSingleRowExplain(query, "SELECT \"C7\" FROM \"" + ORA_TABLE + "\" ORDER BY ABS(\"C7\") DESC");
     }
 
     @Test
@@ -236,8 +236,8 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRow(result, "12345.12345");
             matchNextRow(result, "12355.12345");
         }
-        matchSingleRowExplain(query, "SELECT LIMIT_SUBSELECT.* FROM ( SELECT C7 FROM " + ORA_TABLE
-                + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2");
+        matchSingleRowExplain(query, "SELECT LIMIT_SUBSELECT.* FROM ( SELECT \"C7\" FROM \"" + ORA_TABLE
+                + "\" ORDER BY \"C7\"  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2");
     }
 
     @Test
@@ -247,8 +247,8 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRow(result, "12355.12345");
         }
         matchSingleRowExplain(query,
-                "SELECT c0 FROM ( SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( SELECT C7 AS c0 FROM " + ORA_TABLE
-                        + " ORDER BY C7  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2 ) WHERE ROWNUM_SUB > 1");
+                "SELECT \"c0\" FROM ( SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( SELECT \"C7\" AS c0 FROM \"" + ORA_TABLE
+                        + "\" ORDER BY \"C7\"  ) LIMIT_SUBSELECT WHERE ROWNUM <= 2 ) WHERE ROWNUM_SUB > 1");
     }
 
     @Test
@@ -405,7 +405,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, Date.valueOf("2016-08-19"));
         }
-        runMatchSingleRowExplain(query, "SELECT C10 FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT \"C10\" FROM " + ORA_TABLE + "\"");
         assertEquals("TIMESTAMP", getColumnType("C10"));
     }
 
@@ -415,7 +415,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "11-MAR-13 05.30.15.123 PM");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C11) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C11\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("TIMESTAMP", getColumnType("C11"));
     }
 
@@ -425,7 +425,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "11-MAR-13 05.30.15.123456 PM");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C12) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C12\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("TIMESTAMP", getColumnType("C12"));
     }
 
@@ -435,7 +435,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "11-MAR-13 05.30.15.123456789 PM");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C13) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C13\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("TIMESTAMP", getColumnType("C13"));
     }
 
@@ -445,7 +445,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "19-AUG-16 11.28.05.000000 AM -08:00");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C14) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C14\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("VARCHAR(2000000) UTF8", getColumnType("C14"));
     }
 
@@ -465,7 +465,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
         for (final ResultSet result : runQuery(query)) {
             matchNextRow(result, "+54-02");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C16) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C16\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("VARCHAR(2000000) UTF8", getColumnType("C16"));
     }
 
@@ -476,7 +476,7 @@ public class OracleSqlDialectIT extends AbstractIntegrationTest {
             matchNextRow(result, "+01 11:12:10.123000");
             matchNextRow(result, "+02 02:03:04.123456");
         }
-        runMatchSingleRowExplain(query, "SELECT TO_CHAR(C17) FROM " + ORA_TABLE);
+        runMatchSingleRowExplain(query, "SELECT TO_CHAR(\"C17\") FROM \"" + ORA_TABLE + "\"");
         assertEquals("VARCHAR(2000000) UTF8", getColumnType("C17"));
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/OracleSqlDialectTest.java
@@ -23,12 +23,12 @@ public class OracleSqlDialectTest {
         SqlNode node = DialectTestData.getTestSqlNode();
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT LIMIT_SUBSELECT.* FROM ( " +
-                "  SELECT USER_ID, COUNT(URL) " +
-                "    FROM SCHEMA.CLICKS" +
-                "    WHERE 1 < USER_ID" +
-                "    GROUP BY USER_ID" +
-                "    HAVING 1 < COUNT(URL)" +
-                "    ORDER BY USER_ID " +
+                "  SELECT \"USER_ID\", COUNT(\"URL\") " +
+                "    FROM \"SCHEMA\".\"CLICKS\"" +
+                "    WHERE 1 < \"USER_ID\"" +
+                "    GROUP BY \"USER_ID\"" +
+                "    HAVING 1 < COUNT(\"URL\")" +
+                "    ORDER BY \"USER_ID\" " +
                 ") LIMIT_SUBSELECT WHERE ROWNUM <= 10" ;
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
         SqlDialectContext dialectContext = new SqlDialectContext(Mockito.mock(SchemaAdapterNotes.class));
@@ -45,12 +45,12 @@ public class OracleSqlDialectTest {
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT c0, c1 FROM (" +
                 "  SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( " +
-                "    SELECT USER_ID AS c0, COUNT(URL) AS c1 " +
-                "      FROM SCHEMA.CLICKS" +
-                "      WHERE 1 < USER_ID" +
-                "      GROUP BY USER_ID" +
-                "      HAVING 1 < COUNT(URL)" +
-                "      ORDER BY USER_ID" +
+                "    SELECT \"USER_ID\" AS c0, COUNT(\"URL\") AS c1 " +
+                "      FROM \"SCHEMA\".\"CLICKS\"" +
+                "      WHERE 1 < \"USER_ID\"" +
+                "      GROUP BY \"USER_ID\"" +
+                "      HAVING 1 < COUNT(\"URL\")" +
+                "      ORDER BY \"USER_ID\"" +
                 "  ) LIMIT_SUBSELECT WHERE ROWNUM <= 15 " +
                 ") WHERE ROWNUM_SUB > 5";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);
@@ -69,12 +69,12 @@ public class OracleSqlDialectTest {
         String schemaName = "SCHEMA";
         String expectedSql = "SELECT c0, c1 FROM (" +
                 "  SELECT LIMIT_SUBSELECT.*, ROWNUM ROWNUM_SUB FROM ( " +
-                "    SELECT USER_ID AS c0, URL AS c1 " +
-                "      FROM SCHEMA.CLICKS" +
-                "      WHERE 1 < USER_ID" +
-                "      GROUP BY USER_ID" +
-                "      HAVING 1 < COUNT(URL)" +
-                "      ORDER BY USER_ID" +
+                "    SELECT \"USER_ID\" AS c0, \"URL\" AS c1 " +
+                "      FROM \"SCHEMA\".\"CLICKS\"" +
+                "      WHERE 1 < \"USER_ID\"" +
+                "      GROUP BY \"USER_ID\"" +
+                "      HAVING 1 < COUNT(\"URL\")" +
+                "      ORDER BY \"USER_ID\"" +
                 "  ) LIMIT_SUBSELECT WHERE ROWNUM <= 15 " +
                 ") WHERE ROWNUM_SUB > 5";
         SqlGenerationContext context = new SqlGenerationContext("", schemaName, false);


### PR DESCRIPTION
The fix is to quote all identifiers. This doesn't do any harm and fixes the problem with unquoted keywords.