### PR TITLE
Support for unquoted Postgres identifiers (fix for #74)

### DIFF
--- a/jdbc-adapter/README.md
+++ b/jdbc-adapter/README.md
@@ -136,6 +136,7 @@ Property                    | Value
 **ORA_CONNECTION_NAME**     | Name of the connection to an Oracle database created with `CREATE CONNECTION`. Used by `IMPORT FROM ORA`.
 **IS_LOCAL**                | Only relevant if your data source is the same Exasol database where you create the virtual schema. Either `TRUE` or `FALSE` (default). If true, you are connecting to the local Exasol database (e.g. for testing purposes). In this case, the adapter can avoid the `IMPORT FROM JDBC` overhead.
 **EXCEPTION_HANDLING**      | Activates or deactivates different exception handling modes. Supported values: `IGNORE_INVALID_VIEWS` and `NONE` (default). Currently this property only affects the Teradata dialect.
+**IGNORE_ERRORS**           | Is used to ignore errors thrown by the adapter. Supported values: 'POSTGRESQL_UPPERCASE_TABLES' (see PostgreSQL dialect documentation).
 
 
 ## Debugging

--- a/jdbc-adapter/doc/sql_dialects/postgresql.md
+++ b/jdbc-adapter/doc/sql_dialects/postgresql.md
@@ -48,11 +48,11 @@ CREATE VIRTUAL SCHEMA postgres
 	CATALOG_NAME = 'postgres'
 	SCHEMA_NAME = 'public'
 	CONNECTION_NAME = 'POSTGRES_DOCKER'
-	IGNORE_ERROR_LIST='POSTGRES_IGNORE_UPPERCASE_TABLES'
+	IGNORE_ERRORS = 'POSTGRESQL_UPPERCASE_TABLES'
 ;
 ```
 You can also set this property for an exitsing virtual schema:
 ```sql
-ALTER VIRTUAL SCHEMA postgres SET IGNORE_ERROR_LIST = 'POSTGRES_IGNORE_UPPERCASE_TABLES';
+ALTER VIRTUAL SCHEMA postgres SET IGNORE_ERRORS = 'POSTGRESQL_UPPERCASE_TABLES';
 ```
 However you won't be able to query the identifier containing the upper case character.

--- a/jdbc-adapter/doc/sql_dialects/postgresql.md
+++ b/jdbc-adapter/doc/sql_dialects/postgresql.md
@@ -35,3 +35,24 @@ CREATE VIRTUAL SCHEMA postgres
 	CONNECTION_NAME = 'POSTGRES_DOCKER'
 	;
 ```
+
+## Postgres identifiers
+
+In contrast to EXASOL, PostgreSQL does not treat identifiers as specified in the SQL standard. PostgreSQL folds unquoted identifiers to lower case instead of upper case. The adapter can do the identifier conversion as long as there are no identifiers in the PostgreSQL database that contain upper case characters. If that is the case an error will be thrown when creating or refreshing the virtual schema.
+In order to create or refresh the virtual schema regrardlessly, you can specifiy that the adapter should ignore this specific error:
+```sql
+CREATE VIRTUAL SCHEMA postgres
+	USING adapter.jdbc_adapter 
+	WITH
+	SQL_DIALECT = 'POSTGRESQL'
+	CATALOG_NAME = 'postgres'
+	SCHEMA_NAME = 'public'
+	CONNECTION_NAME = 'POSTGRES_DOCKER'
+	IGNORE_ERROR_LIST='POSTGRES_IGNORE_UPPERCASE_TABLES'
+;
+```
+You can also set this property for an exitsing virtual schema:
+```sql
+ALTER VIRTUAL SCHEMA postgres SET IGNORE_ERROR_LIST = 'POSTGRES_IGNORE_UPPERCASE_TABLES';
+```
+However you won't be able to query the identifier containing the upper case character.

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
@@ -3,11 +3,7 @@ package com.exasol.adapter.dialects;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import com.exasol.adapter.jdbc.ColumnAdapterNotes;
 import com.exasol.adapter.jdbc.JdbcAdapterProperties;
@@ -40,7 +36,7 @@ public abstract class AbstractSqlDialect implements SqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
         String commentString = tables.getString("REMARKS");
         if (commentString == null) {
             commentString = "";

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
@@ -40,7 +40,7 @@ public abstract class AbstractSqlDialect implements SqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
         String commentString = tables.getString("REMARKS");
         if (commentString == null) {
             commentString = "";

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
@@ -36,7 +36,7 @@ public abstract class AbstractSqlDialect implements SqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, final List<String> ignoreErrorList) throws SQLException {
         String commentString = tables.getString("REMARKS");
         if (commentString == null) {
             commentString = "";

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
@@ -154,10 +154,10 @@ public interface SqlDialect {
      * @param tables A jdbc Resultset for the
      *               {@link DatabaseMetaData#getTables(String, String, String, String[])}
      *               call, pointing to the current table.
-     * @param ignoreErrorList
+     * @param ignoreErrorList The elements of this list suppress certain errors the adapter would throw
      * @return An instance of {@link MappedTable} describing the mapped table.
      */
-    public MappedTable mapTable(ResultSet tables, List<String> ignoreErrorList) throws SQLException;
+    public MappedTable mapTable(ResultSet tables, final List<String> ignoreErrorList) throws SQLException;
 
     /**
      * @param columns A jdbc Resultset for the

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
@@ -3,6 +3,7 @@ package com.exasol.adapter.dialects;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 
 import com.exasol.adapter.capabilities.Capabilities;
@@ -156,7 +157,7 @@ public interface SqlDialect {
      * @param ignoreErrorList
      * @return An instance of {@link MappedTable} describing the mapped table.
      */
-    public MappedTable mapTable(ResultSet tables, String ignoreErrorList) throws SQLException;
+    public MappedTable mapTable(ResultSet tables, List<String> ignoreErrorList) throws SQLException;
 
     /**
      * @param columns A jdbc Resultset for the

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/SqlDialect.java
@@ -153,9 +153,10 @@ public interface SqlDialect {
      * @param tables A jdbc Resultset for the
      *               {@link DatabaseMetaData#getTables(String, String, String, String[])}
      *               call, pointing to the current table.
+     * @param ignoreErrorList
      * @return An instance of {@link MappedTable} describing the mapped table.
      */
-    public MappedTable mapTable(ResultSet tables) throws SQLException;
+    public MappedTable mapTable(ResultSet tables, String ignoreErrorList) throws SQLException;
 
     /**
      * @param columns A jdbc Resultset for the

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
@@ -332,7 +332,7 @@ public class OracleSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, final List<String> ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
         if (tableName.startsWith("BIN$")) {
             // In case of Oracle we may see deleted tables with strange names

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 import com.exasol.adapter.capabilities.AggregateFunctionCapability;
@@ -331,7 +332,7 @@ public class OracleSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
         if (tableName.startsWith("BIN$")) {
             // In case of Oracle we may see deleted tables with strange names

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/OracleSqlDialect.java
@@ -331,7 +331,7 @@ public class OracleSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
         if (tableName.startsWith("BIN$")) {
             // In case of Oracle we may see deleted tables with strange names
@@ -341,7 +341,7 @@ public class OracleSqlDialect extends AbstractSqlDialect {
             System.out.println("Skip table: " + tableName);
             return MappedTable.createIgnoredTable();
         } else {
-            return super.mapTable(tables);
+            return super.mapTable(tables, ignoreErrorList);
         }
     }
 

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -6,7 +6,6 @@ import java.sql.Types;
 import java.util.EnumMap;
 import java.util.Map;
 
-import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.capabilities.AggregateFunctionCapability;
 import com.exasol.adapter.capabilities.Capabilities;
 import com.exasol.adapter.capabilities.LiteralCapability;
@@ -300,15 +299,22 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
         return colType;
     }
 
+    //TODO: write unittest for ignoreerrorlist
+    //TODO: make return type of ignoreerrorlist an actial List<String>
+    //TODO: write integrationtest
     @Override
-    public MappedTable mapTable(final ResultSet tables) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
+        //TODO: remove magic value
+        if (ignoreErrorList.equals("POSTGRES_IGNORE_UPPERCASE_TABLES")) {
+            return super.mapTable(tables, ignoreErrorList);
+        }
         if (!tableName.equals(tableName.toLowerCase())) {
             //TODO: think about a good error message
             throw new IllegalArgumentException("Table " + tableName + " cannot be used in virtual schema. " +
-                    "Use property POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
+                    "Set property IGNORE_ERROR_LIST to POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
         } else {
-            return super.mapTable(tables);
+            return super.mapTable(tables, ignoreErrorList);
         }
     }
 

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -22,6 +22,9 @@ import com.exasol.adapter.metadata.DataType;
 import com.exasol.adapter.sql.ScalarFunction;
 
 public class PostgreSQLSqlDialect extends AbstractSqlDialect {
+
+    public static final String POSTGRES_IGNORE_UPPERCASE_TABLES = "POSTGRES_IGNORE_UPPERCASE_TABLES";
+
     public PostgreSQLSqlDialect(final SqlDialectContext context) {
         super(context);
     }
@@ -300,23 +303,22 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
         return colType;
     }
 
-    //TODO: write unittest for ignoreerrorlist
-    //TODO: make return type of ignoreerrorlist an actial List<String>
-    //TODO: write integrationtest
     @Override
     public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
-        //TODO: remove magic value
-        if (ignoreErrorList.equals("POSTGRES_IGNORE_UPPERCASE_TABLES")) {
+        if (ignoreErrorList.contains(POSTGRES_IGNORE_UPPERCASE_TABLES)) {
             return super.mapTable(tables, ignoreErrorList);
         }
-        if (!tableName.equals(tableName.toLowerCase())) {
-            //TODO: think about a good error message
+        if (containsUppercaseCharacter(tableName)) {
             throw new IllegalArgumentException("Table " + tableName + " cannot be used in virtual schema. " +
                     "Set property IGNORE_ERROR_LIST to POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
         } else {
             return super.mapTable(tables, ignoreErrorList);
         }
+    }
+
+    private boolean containsUppercaseCharacter(String tableName) {
+        return !tableName.equals(tableName.toLowerCase());
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -23,7 +23,7 @@ import com.exasol.adapter.sql.ScalarFunction;
 
 public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
-    public static final String POSTGRES_IGNORE_UPPERCASE_TABLES = "POSTGRES_IGNORE_UPPERCASE_TABLES";
+    public static final String POSTGRES_IGNORE_UPPERCASE_TABLES = "POSTGRES_UPPERCASE_TABLES";
 
     public PostgreSQLSqlDialect(final SqlDialectContext context) {
         super(context);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -1,10 +1,12 @@
 package com.exasol.adapter.dialects.impl;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.EnumMap;
 import java.util.Map;
 
+import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.capabilities.AggregateFunctionCapability;
 import com.exasol.adapter.capabilities.Capabilities;
 import com.exasol.adapter.capabilities.LiteralCapability;
@@ -296,6 +298,18 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
         }
 
         return colType;
+    }
+
+    @Override
+    public MappedTable mapTable(final ResultSet tables) throws SQLException {
+        final String tableName = tables.getString("TABLE_NAME");
+        if (!tableName.equals(tableName.toLowerCase())) {
+            //TODO: think about a good error message
+            throw new IllegalArgumentException("Table " + tableName + " cannot be used in virtual schema. " +
+                    "Use property POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
+        } else {
+            return super.mapTable(tables);
+        }
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -304,12 +304,9 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
-    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, final List<String> ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
-        if (ignoreErrorList.contains(POSTGRES_IGNORE_UPPERCASE_TABLES)) {
-            return super.mapTable(tables, ignoreErrorList);
-        }
-        if (containsUppercaseCharacter(tableName)) {
+        if (!ignoreErrorList.contains(POSTGRES_IGNORE_UPPERCASE_TABLES) && containsUppercaseCharacter(tableName)) {
             throw new IllegalArgumentException("Table " + tableName + " cannot be used in virtual schema. " +
                     "Set property IGNORE_ERROR_LIST to POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
         } else {
@@ -317,7 +314,7 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
         }
     }
 
-    private boolean containsUppercaseCharacter(String tableName) {
+    private boolean containsUppercaseCharacter(final String tableName) {
         return !tableName.equals(tableName.toLowerCase());
     }
 
@@ -368,7 +365,12 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuote(final String identifier) {
-        return "\"" + identifier.toLowerCase().replace("\"", "\"\"") + "\"";
+        final String lowercaseIdentifier = convertIdentifierToLowerCase(identifier);
+        return "\"" + lowercaseIdentifier.replace("\"", "\"\"") + "\"";
+    }
+
+    private String convertIdentifierToLowerCase(final String identifier) {
+        return identifier.toLowerCase();
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -345,7 +345,7 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
     @Override
     public String applyQuote(final String identifier) {
-        return "\"" + identifier.replace("\"", "\"\"") + "\"";
+        return "\"" + identifier.toLowerCase().replace("\"", "\"\"") + "\"";
     }
 
     @Override

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -23,7 +23,7 @@ import com.exasol.adapter.sql.ScalarFunction;
 
 public class PostgreSQLSqlDialect extends AbstractSqlDialect {
 
-    public static final String POSTGRES_IGNORE_UPPERCASE_TABLES = "POSTGRES_UPPERCASE_TABLES";
+    public static final String POSTGRES_IGNORE_UPPERCASE_TABLES = "POSTGRESQL_UPPERCASE_TABLES";
 
     public PostgreSQLSqlDialect(final SqlDialectContext context) {
         super(context);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -308,7 +308,7 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
         final String tableName = tables.getString("TABLE_NAME");
         if (!ignoreErrorList.contains(POSTGRES_IGNORE_UPPERCASE_TABLES) && containsUppercaseCharacter(tableName)) {
             throw new IllegalArgumentException("Table " + tableName + " cannot be used in virtual schema. " +
-                    "Set property IGNORE_ERROR_LIST to POSTGRES_IGNORE_UPPERCASE_TABLES to enforce schema creation.");
+                    "Set property IGNORE_ERRORS to POSTGRES_UPPERCASE_TABLES to enforce schema creation.");
         } else {
             return super.mapTable(tables, ignoreErrorList);
         }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialect.java
@@ -4,6 +4,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
 
 import com.exasol.adapter.capabilities.AggregateFunctionCapability;
@@ -303,7 +304,7 @@ public class PostgreSQLSqlDialect extends AbstractSqlDialect {
     //TODO: make return type of ignoreerrorlist an actial List<String>
     //TODO: write integrationtest
     @Override
-    public MappedTable mapTable(final ResultSet tables, String ignoreErrorList) throws SQLException {
+    public MappedTable mapTable(final ResultSet tables, List<String> ignoreErrorList) throws SQLException {
         final String tableName = tables.getString("TABLE_NAME");
         //TODO: remove magic value
         if (ignoreErrorList.equals("POSTGRES_IGNORE_UPPERCASE_TABLES")) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -135,7 +135,8 @@ public class JdbcAdapter {
         return JdbcMetadataReader.readRemoteMetadata(connection.getAddress(), connection.getUser(),
                 connection.getPassword(), catalog, schema, tables,
                 JdbcAdapterProperties.getSqlDialectName(meta.getProperties()),
-                JdbcAdapterProperties.getExceptionHandlingMode(meta.getProperties()));
+                JdbcAdapterProperties.getExceptionHandlingMode(meta.getProperties()),
+                JdbcAdapterProperties.getIgnoreErrorList(meta.getProperties()));
     }
 
     private static String handleRefresh(final RefreshRequest request, final ExaMetadata meta)
@@ -165,7 +166,8 @@ public class JdbcAdapter {
                     connection.getUser(), connection.getPassword(), JdbcAdapterProperties.getCatalog(newSchemaMeta),
                     JdbcAdapterProperties.getSchema(newSchemaMeta), tableFilter,
                     JdbcAdapterProperties.getSqlDialectName(newSchemaMeta),
-                    JdbcAdapterProperties.getExceptionHandlingMode(newSchemaMeta));
+                    JdbcAdapterProperties.getExceptionHandlingMode(newSchemaMeta),
+                    JdbcAdapterProperties.getIgnoreErrorList(newSchemaMeta));
             return ResponseJsonSerializer.makeSetPropertiesResponse(remoteMeta);
         }
         return ResponseJsonSerializer.makeSetPropertiesResponse(null);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -66,27 +66,34 @@ public final class JdbcAdapterProperties {
         }
     }
 
+    private static String getProperty(final Map<String, String> properties, final String name) {
+        return getProperty(properties, name, "");
+    }
+
     public static List<String> getIgnoreErrorList(final Map<String, String> properties) {
-        String ignoreErrors = getProperty(properties, PROP_IGNORE_ERROR_LIST, "");
-        List<String> ignoreErrorsList = Arrays.asList(ignoreErrors.split(","));
-        return ignoreErrorsList.stream().map(error -> error.trim().toUpperCase()).collect(Collectors.toList());
+        final String ignoreErrors = getProperty(properties, PROP_IGNORE_ERROR_LIST);
+        return Arrays.
+                stream(ignoreErrors.split(","))
+                .map(String::trim)
+                .map(String::toUpperCase)
+                .collect(Collectors.toList());
     }
 
     public static String getCatalog(final Map<String, String> properties) {
-        return getProperty(properties, PROP_CATALOG_NAME, "");
+        return getProperty(properties, PROP_CATALOG_NAME);
     }
 
     public static String getSchema(final Map<String, String> properties) {
-        return getProperty(properties, PROP_SCHEMA_NAME, "");
+        return getProperty(properties, PROP_SCHEMA_NAME);
     }
 
     public static boolean userSpecifiedConnection(final Map<String, String> properties) {
-        final String connName = getProperty(properties, PROP_CONNECTION_NAME, "");
+        final String connName = getProperty(properties, PROP_CONNECTION_NAME);
         return (connName != null && !connName.isEmpty());
     }
 
     public static String getConnectionName(final Map<String, String> properties) {
-        final String connName = getProperty(properties, PROP_CONNECTION_NAME, "");
+        final String connName = getProperty(properties, PROP_CONNECTION_NAME);
         assert (connName != null && !connName.isEmpty());
         return connName;
     }
@@ -98,7 +105,7 @@ public final class JdbcAdapterProperties {
      */
     public static ExaConnectionInformation getConnectionInformation(final Map<String, String> properties,
             final ExaMetadata exaMeta) {
-        final String connName = getProperty(properties, PROP_CONNECTION_NAME, "");
+        final String connName = getProperty(properties, PROP_CONNECTION_NAME);
         if (connName != null && !connName.isEmpty()) {
             try {
                 final ExaConnectionInformation connInfo = exaMeta.getConnection(connName);
@@ -124,8 +131,8 @@ public final class JdbcAdapterProperties {
 
     private static void checkImportPropertyConsistency(final Map<String, String> properties,
             final String propImportFromX, final String propConnection) throws InvalidPropertyException {
-        final boolean isImport = getProperty(properties, propImportFromX, "").toUpperCase().equals("TRUE");
-        final boolean connectionIsEmpty = getProperty(properties, propConnection, "").isEmpty();
+        final boolean isImport = getProperty(properties, propImportFromX).toUpperCase().equals("TRUE");
+        final boolean connectionIsEmpty = getProperty(properties, propConnection).isEmpty();
         if (isImport) {
             if (connectionIsEmpty) {
                 throw new InvalidPropertyException(
@@ -214,23 +221,23 @@ public final class JdbcAdapterProperties {
     }
 
     public static boolean isImportFromExa(final Map<String, String> properties) {
-        return getProperty(properties, PROP_IMPORT_FROM_EXA, "").toUpperCase().equals("TRUE");
+        return getProperty(properties, PROP_IMPORT_FROM_EXA).toUpperCase().equals("TRUE");
     }
 
     public static boolean isImportFromOra(final Map<String, String> properties) {
-        return getProperty(properties, PROP_IMPORT_FROM_ORA, "").toUpperCase().equals("TRUE");
+        return getProperty(properties, PROP_IMPORT_FROM_ORA).toUpperCase().equals("TRUE");
     }
 
     public static String getExaConnectionString(final Map<String, String> properties) {
-        return getProperty(properties, PROP_EXA_CONNECTION_STRING, "");
+        return getProperty(properties, PROP_EXA_CONNECTION_STRING);
     }
 
     public static String getOraConnectionName(final Map<String, String> properties) {
-        return getProperty(properties, PROP_ORA_CONNECTION_NAME, "");
+        return getProperty(properties, PROP_ORA_CONNECTION_NAME);
     }
 
     public static List<String> getTableFilter(final Map<String, String> properties) {
-        final String tableNames = getProperty(properties, PROP_TABLES, "");
+        final String tableNames = getProperty(properties, PROP_TABLES);
         if (!tableNames.isEmpty()) {
             final List<String> tables = Arrays.asList(tableNames.split(","));
             for (int i = 0; i < tables.size(); ++i) {
@@ -243,24 +250,24 @@ public final class JdbcAdapterProperties {
     }
 
     public static String getExcludedCapabilities(final Map<String, String> properties) {
-        return getProperty(properties, PROP_EXCLUDED_CAPABILITIES, "");
+        return getProperty(properties, PROP_EXCLUDED_CAPABILITIES);
     }
 
     public static String getDebugAddress(final Map<String, String> properties) {
-        return getProperty(properties, PROP_DEBUG_ADDRESS, "");
+        return getProperty(properties, PROP_DEBUG_ADDRESS);
     }
 
     public static boolean isLocal(final Map<String, String> properties) {
-        return getProperty(properties, PROP_IS_LOCAL, "").toUpperCase().equals("TRUE");
+        return getProperty(properties, PROP_IS_LOCAL).toUpperCase().equals("TRUE");
     }
 
     public static String getSqlDialectName(final Map<String, String> properties) {
-        return getProperty(properties, PROP_SQL_DIALECT, "");
+        return getProperty(properties, PROP_SQL_DIALECT);
     }
 
     public static SqlDialect getSqlDialect(final Map<String, String> properties, final SqlDialectContext dialectContext)
             throws InvalidPropertyException {
-        final String dialectName = getProperty(properties, PROP_SQL_DIALECT, "");
+        final String dialectName = getProperty(properties, PROP_SQL_DIALECT);
         final SqlDialect dialect = SqlDialects.getInstance().getDialectInstanceForNameWithContext(dialectName,
                 dialectContext);
         if (dialect == null) {
@@ -271,7 +278,7 @@ public final class JdbcAdapterProperties {
     }
 
     public static ExceptionHandlingMode getExceptionHandlingMode(final Map<String, String> properties) {
-        final String propertyValue = getProperty(properties, PROP_EXCEPTION_HANDLING, "");
+        final String propertyValue = getProperty(properties, PROP_EXCEPTION_HANDLING);
         if (propertyValue == null || propertyValue.isEmpty()) {
             return ExceptionHandlingMode.NONE;
         }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -1,10 +1,6 @@
 package com.exasol.adapter.jdbc;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -72,6 +68,9 @@ public final class JdbcAdapterProperties {
 
     public static List<String> getIgnoreErrorList(final Map<String, String> properties) {
         final String ignoreErrors = getProperty(properties, PROP_IGNORE_ERROR_LIST);
+        if (ignoreErrors.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
         return Arrays.
                 stream(ignoreErrors.split(","))
                 .map(String::trim)
@@ -127,6 +126,19 @@ public final class JdbcAdapterProperties {
         checkMandatoryProperties(properties);
         checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_EXA, PROP_EXA_CONNECTION_STRING);
         checkImportPropertyConsistency(properties, PROP_IMPORT_FROM_ORA, PROP_ORA_CONNECTION_NAME);
+        checkIgnoreErrors(properties);
+    }
+
+    private static void checkIgnoreErrors(final Map<String, String> properties) throws InvalidPropertyException {
+        final String dialect = getSqlDialectName(properties);
+        List<String> errorsToIgnore = getIgnoreErrorList(properties);
+        for (String errorToIgnore : errorsToIgnore) {
+            if (!errorToIgnore.startsWith(dialect)) {
+                throw new InvalidPropertyException(
+                        "Error " + errorToIgnore + " cannot be ignored in " + dialect + " dialect."
+                );
+            }
+        }
     }
 
     private static void checkImportPropertyConsistency(final Map<String, String> properties,

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -44,7 +44,7 @@ public final class JdbcAdapterProperties {
     static final String PROP_EXCLUDED_CAPABILITIES = "EXCLUDED_CAPABILITIES";
     static final String PROP_EXCEPTION_HANDLING = "EXCEPTION_HANDLING";
     static final String PROP_LOG_LEVEL = "LOG_LEVEL";
-    static final String PROP_IGNORE_ERROR_LIST = "IGNORE_ERROR_LIST";
+    static final String PROP_IGNORE_ERROR_LIST = "IGNORE_ERRORS";
 
     private static final String DEFAULT_LOG_LEVEL = "INFO";
 

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -43,6 +43,7 @@ public final class JdbcAdapterProperties {
     static final String PROP_EXCLUDED_CAPABILITIES = "EXCLUDED_CAPABILITIES";
     static final String PROP_EXCEPTION_HANDLING = "EXCEPTION_HANDLING";
     static final String PROP_LOG_LEVEL = "LOG_LEVEL";
+    static final String PROP_IGNORE_ERROR_LIST = "IGNORE_ERROR_LIST";
 
     private static final String DEFAULT_LOG_LEVEL = "INFO";
 
@@ -62,6 +63,10 @@ public final class JdbcAdapterProperties {
         } else {
             return defaultValue;
         }
+    }
+
+    public static String getIgnoreErrorList(final Map<String, String> properties) {
+        return getProperty(properties, PROP_IGNORE_ERROR_LIST, "");
     }
 
     public static String getCatalog(final Map<String, String> properties) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.exasol.ExaConnectionAccessException;
 import com.exasol.ExaConnectionInformation;
@@ -65,8 +66,10 @@ public final class JdbcAdapterProperties {
         }
     }
 
-    public static String getIgnoreErrorList(final Map<String, String> properties) {
-        return getProperty(properties, PROP_IGNORE_ERROR_LIST, "");
+    public static List<String> getIgnoreErrorList(final Map<String, String> properties) {
+        String ignoreErrors = getProperty(properties, PROP_IGNORE_ERROR_LIST, "");
+        List<String> ignoreErrorsList = Arrays.asList(ignoreErrors.split(","));
+        return ignoreErrorsList.stream().map(error -> error.trim()).collect(Collectors.toList());
     }
 
     public static String getCatalog(final Map<String, String> properties) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -69,7 +69,7 @@ public final class JdbcAdapterProperties {
     public static List<String> getIgnoreErrorList(final Map<String, String> properties) {
         String ignoreErrors = getProperty(properties, PROP_IGNORE_ERROR_LIST, "");
         List<String> ignoreErrorsList = Arrays.asList(ignoreErrors.split(","));
-        return ignoreErrorsList.stream().map(error -> error.trim()).collect(Collectors.toList());
+        return ignoreErrorsList.stream().map(error -> error.trim().toUpperCase()).collect(Collectors.toList());
     }
 
     public static String getCatalog(final Map<String, String> properties) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
@@ -20,7 +20,7 @@ public class JdbcMetadataReader {
 
     public static SchemaMetadata readRemoteMetadata(final String connectionString, final String user,
             final String password, String catalog, String schema, final List<String> tableFilter,
-            final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, final String ignoreErrorList)
+            final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, final List<String> ignoreErrorList)
             throws SQLException, AdapterException {
         assert (catalog != null);
         assert (schema != null);
@@ -243,7 +243,7 @@ public class JdbcMetadataReader {
 
     private static List<TableMetadata> findTables(final String catalog, final String schema,
                                                   final List<String> tableFilter, final DatabaseMetaData dbMeta, final SqlDialect dialect,
-                                                  final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, String ignoreErrorList) throws SQLException {
+                                                  final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, List<String> ignoreErrorList) throws SQLException {
         final List<TableMetadata> tables = new ArrayList<>();
 
         final String[] supportedTableTypes = { "TABLE", "VIEW", "SYSTEM TABLE" };

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
@@ -20,7 +20,7 @@ public class JdbcMetadataReader {
 
     public static SchemaMetadata readRemoteMetadata(final String connectionString, final String user,
             final String password, String catalog, String schema, final List<String> tableFilter,
-            final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode)
+            final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, final String ignoreErrorList)
             throws SQLException, AdapterException {
         assert (catalog != null);
         assert (schema != null);
@@ -45,7 +45,7 @@ public class JdbcMetadataReader {
 
             schema = findSchema(schema, dbMeta, dialect);
 
-            final List<TableMetadata> tables = findTables(catalog, schema, tableFilter, dbMeta, dialect, exceptionMode);
+            final List<TableMetadata> tables = findTables(catalog, schema, tableFilter, dbMeta, dialect, exceptionMode, ignoreErrorList);
 
             conn.close();
             return new SchemaMetadata(SchemaAdapterNotes.serialize(schemaAdapterNotes), tables);
@@ -242,8 +242,8 @@ public class JdbcMetadataReader {
     }
 
     private static List<TableMetadata> findTables(final String catalog, final String schema,
-            final List<String> tableFilter, final DatabaseMetaData dbMeta, final SqlDialect dialect,
-            final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode) throws SQLException {
+                                                  final List<String> tableFilter, final DatabaseMetaData dbMeta, final SqlDialect dialect,
+                                                  final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, String ignoreErrorList) throws SQLException {
         final List<TableMetadata> tables = new ArrayList<>();
 
         final String[] supportedTableTypes = { "TABLE", "VIEW", "SYSTEM TABLE" };
@@ -252,7 +252,7 @@ public class JdbcMetadataReader {
         final List<SqlDialect.MappedTable> tablesMapped = new ArrayList<>();
         // List<String> tableComments = new ArrayList<>();
         while (resTables.next()) {
-            final SqlDialect.MappedTable mappedTable = dialect.mapTable(resTables);
+            final SqlDialect.MappedTable mappedTable = dialect.mapTable(resTables, ignoreErrorList);
             if (!mappedTable.isIgnored()) {
                 tablesMapped.add(mappedTable);
                 // tableComments.add(mappedTable.getTableComment());

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcMetadataReader.java
@@ -19,13 +19,12 @@ public class JdbcMetadataReader {
     private static final Logger LOGGER = Logger.getLogger(JdbcMetadataReader.class.getName());
 
     public static SchemaMetadata readRemoteMetadata(final String connectionString, final String user,
-            final String password, String catalog, String schema, final List<String> tableFilter,
-            final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, final List<String> ignoreErrorList)
+                                                    final String password, String catalog, String schema, final List<String> tableFilter,
+                                                    final String dialectName, final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, final List<String> ignoreErrorList)
             throws SQLException, AdapterException {
         assert (catalog != null);
         assert (schema != null);
-        try {
-            final Connection conn = establishConnection(connectionString, user, password);
+        try (final Connection conn = establishConnection(connectionString, user, password);) {
             final DatabaseMetaData dbMeta = conn.getMetaData();
 
             // Retrieve relevant parts of DatabaseMetadata. Will be cached in adapternotes
@@ -47,7 +46,6 @@ public class JdbcMetadataReader {
 
             final List<TableMetadata> tables = findTables(catalog, schema, tableFilter, dbMeta, dialect, exceptionMode, ignoreErrorList);
 
-            conn.close();
             return new SchemaMetadata(SchemaAdapterNotes.serialize(schemaAdapterNotes), tables);
         } catch (final SQLException e) {
             e.printStackTrace();
@@ -56,7 +54,7 @@ public class JdbcMetadataReader {
     }
 
     private static Connection establishConnection(final String connectionString, final String user,
-            final String password) throws SQLException {
+                                                  final String password) throws SQLException {
         LOGGER.fine(() -> "Establishing connection with paramters: " + connectionString);
         final java.util.Properties info = new java.util.Properties();
         if (user != null) {
@@ -246,20 +244,19 @@ public class JdbcMetadataReader {
                                                   final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode, List<String> ignoreErrorList) throws SQLException {
         final List<TableMetadata> tables = new ArrayList<>();
 
-        final String[] supportedTableTypes = { "TABLE", "VIEW", "SYSTEM TABLE" };
+        final String[] supportedTableTypes = {"TABLE", "VIEW", "SYSTEM TABLE"};
 
-        final ResultSet resTables = dbMeta.getTables(catalog, schema, null, supportedTableTypes);
         final List<SqlDialect.MappedTable> tablesMapped = new ArrayList<>();
-        // List<String> tableComments = new ArrayList<>();
-        while (resTables.next()) {
-            final SqlDialect.MappedTable mappedTable = dialect.mapTable(resTables, ignoreErrorList);
-            if (!mappedTable.isIgnored()) {
-                tablesMapped.add(mappedTable);
-                // tableComments.add(mappedTable.getTableComment());
+        try (final ResultSet resTables = dbMeta.getTables(catalog, schema, null, supportedTableTypes)) {
+            // List<String> tableComments = new ArrayList<>();
+            while (resTables.next()) {
+                final SqlDialect.MappedTable mappedTable = dialect.mapTable(resTables, ignoreErrorList);
+                if (!mappedTable.isIgnored()) {
+                    tablesMapped.add(mappedTable);
+                    // tableComments.add(mappedTable.getTableComment());
+                }
             }
         }
-
-        resTables.close();
 
         // Columns
         for (int i = 0; i < tablesMapped.size(); ++i) {
@@ -300,8 +297,8 @@ public class JdbcMetadataReader {
     }
 
     private static List<ColumnMetadata> readColumns(final DatabaseMetaData dbMeta, final String catalog,
-            final String schema, final String table, final SqlDialect dialect,
-            final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode) throws SQLException {
+                                                    final String schema, final String table, final SqlDialect dialect,
+                                                    final JdbcAdapterProperties.ExceptionHandlingMode exceptionMode) throws SQLException {
         final List<ColumnMetadata> columns = new ArrayList<>();
         try {
             final ResultSet cols = dbMeta.getColumns(catalog, schema, table, null);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -308,7 +308,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         final List<String> tables = new ArrayList<>(Arrays.asList(tableNames));
         final SchemaMetadata meta = JdbcMetadataReader.readRemoteMetadata("jdbc:exa:" + getConfig().getExasolAddress(),
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "EXA_DB", "JDBC_ADAPTER_TEST_SCHEMA",
-                tables, ExasolSqlDialect.getPublicName(), getConfig().getExceptionHandlingMode());
+                tables, ExasolSqlDialect.getPublicName(), getConfig().getExceptionHandlingMode(), "");
         if (getConfig().isDebugOn()) {
             System.out.println("Meta: " + SchemaMetadataSerializer.serialize(meta).build().toString());
         }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assume;
@@ -308,7 +309,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         final List<String> tables = new ArrayList<>(Arrays.asList(tableNames));
         final SchemaMetadata meta = JdbcMetadataReader.readRemoteMetadata("jdbc:exa:" + getConfig().getExasolAddress(),
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "EXA_DB", "JDBC_ADAPTER_TEST_SCHEMA",
-                tables, ExasolSqlDialect.getPublicName(), getConfig().getExceptionHandlingMode(), "");
+                tables, ExasolSqlDialect.getPublicName(), getConfig().getExceptionHandlingMode(), Collections.emptyList());
         if (getConfig().isDebugOn()) {
             System.out.println("Meta: " + SchemaMetadataSerializer.serialize(meta).build().toString());
         }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -1,0 +1,53 @@
+package com.exasol.adapter.dialects.impl;
+
+import com.exasol.adapter.dialects.SqlDialectContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+public class PostgreSQLSqlDialectTest {
+    @Mock
+    SqlDialectContext sqlDialectContext;
+
+
+    @Before
+    public void setUp() throws SQLException {
+
+    }
+
+    @Test
+    public void applyQuoteOnUpperCase() {
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        assertEquals("\"abc\"", postgresDialect.applyQuote("ABC"));
+    }
+
+    @Test
+    public void applyQuoteOnMixedCase() {
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        assertEquals("\"abcde\"", postgresDialect.applyQuote("AbCde"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void mapTableWithUpperCaseCharacters() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("TABLE_NAME")).thenReturn("uPPer");
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        postgresDialect.mapTable(resultSet);
+    }
+
+    @Test
+    public void mapTableWithLowerCaseCharacters() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("TABLE_NAME")).thenReturn("lower");
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        postgresDialect.mapTable(resultSet);
+    }
+}

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -67,7 +67,7 @@ public class PostgreSQLSqlDialectTest {
         when(resultSet.getString("TABLE_NAME")).thenReturn("Upper");
         List<String> ignoreList = new ArrayList<>();
         ignoreList.add("Dummy_Error");
-        ignoreList.add("POSTGRES_UPPERCASE_TABLES");
+        ignoreList.add("POSTGRESQL_UPPERCASE_TABLES");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         postgresDialect.mapTable(resultSet, ignoreList);
     }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -8,7 +8,9 @@ import static org.mockito.Mockito.*;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -50,5 +52,16 @@ public class PostgreSQLSqlDialectTest {
         when(resultSet.getString("TABLE_NAME")).thenReturn("lower");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         postgresDialect.mapTable(resultSet, Collections.emptyList());
+    }
+
+    @Test
+    public void mapTableWithIgnoreUppercaseCharactersError() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("TABLE_NAME")).thenReturn("Upper");
+        List<String> ignoreList = new ArrayList<>();
+        ignoreList.add("Dummy_Error");
+        ignoreList.add("POSTGRES_IGNORE_UPPERCASE_TABLES");
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        postgresDialect.mapTable(resultSet, ignoreList);
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collections;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -40,7 +41,7 @@ public class PostgreSQLSqlDialectTest {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("uPPer");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
-        postgresDialect.mapTable(resultSet, "");
+        postgresDialect.mapTable(resultSet, Collections.emptyList());
     }
 
     @Test
@@ -48,6 +49,6 @@ public class PostgreSQLSqlDialectTest {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("lower");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
-        postgresDialect.mapTable(resultSet, "");
+        postgresDialect.mapTable(resultSet, Collections.emptyList());
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -40,7 +40,7 @@ public class PostgreSQLSqlDialectTest {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("uPPer");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
-        postgresDialect.mapTable(resultSet);
+        postgresDialect.mapTable(resultSet, "");
     }
 
     @Test
@@ -48,6 +48,6 @@ public class PostgreSQLSqlDialectTest {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("lower");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
-        postgresDialect.mapTable(resultSet);
+        postgresDialect.mapTable(resultSet, "");
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -67,7 +67,7 @@ public class PostgreSQLSqlDialectTest {
         when(resultSet.getString("TABLE_NAME")).thenReturn("Upper");
         List<String> ignoreList = new ArrayList<>();
         ignoreList.add("Dummy_Error");
-        ignoreList.add("POSTGRES_IGNORE_UPPERCASE_TABLES");
+        ignoreList.add("POSTGRES_UPPERCASE_TABLES");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         postgresDialect.mapTable(resultSet, ignoreList);
     }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/PostgreSQLSqlDialectTest.java
@@ -20,34 +20,41 @@ public class PostgreSQLSqlDialectTest {
     @Mock
     SqlDialectContext sqlDialectContext;
 
-
     @Before
     public void setUp() throws SQLException {
 
     }
 
     @Test
-    public void applyQuoteOnUpperCase() {
+    public void testApplyQuoteOnUpperCase() {
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         assertEquals("\"abc\"", postgresDialect.applyQuote("ABC"));
     }
 
     @Test
-    public void applyQuoteOnMixedCase() {
+    public void testApplyQuoteOnMixedCase() {
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         assertEquals("\"abcde\"", postgresDialect.applyQuote("AbCde"));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void mapTableWithUpperCaseCharacters() throws SQLException {
+    public void testMapTableWithUpperCaseCharactersAndNoErrorIgnoredThrowsException() throws SQLException {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("uPPer");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
         postgresDialect.mapTable(resultSet, Collections.emptyList());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testMapTableWithRussianUpperCaseCharactersAndNoErrorIgnoredThrowsException() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        when(resultSet.getString("TABLE_NAME")).thenReturn("аППер");
+        PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
+        postgresDialect.mapTable(resultSet, Collections.emptyList());
+    }
+
     @Test
-    public void mapTableWithLowerCaseCharacters() throws SQLException {
+    public void testMapTableWithLowerCaseCharacters() throws SQLException {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("lower");
         PostgreSQLSqlDialect postgresDialect = new PostgreSQLSqlDialect(sqlDialectContext);
@@ -55,7 +62,7 @@ public class PostgreSQLSqlDialectTest {
     }
 
     @Test
-    public void mapTableWithIgnoreUppercaseCharactersError() throws SQLException {
+    public void testMapTableWithIgnoreUppercaseCharactersError() throws SQLException {
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.getString("TABLE_NAME")).thenReturn("Upper");
         List<String> ignoreList = new ArrayList<>();

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
@@ -2,6 +2,7 @@ package com.exasol.adapter.jdbc;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -245,5 +246,16 @@ public class JdbcAdapterPropertiesTest {
         assertEquals(JdbcAdapterProperties.ExceptionHandlingMode.NONE,
                 JdbcAdapterProperties.getExceptionHandlingMode(properties));
         JdbcAdapterProperties.checkPropertyConsistency(properties);
+    }
+
+    @Test
+    public void getIgnoreErrorList() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("IGNORE_ERROR_LIST", "ERrror_foo, error_bar    ,  another_error");
+        List<String> expectedErrorList = new ArrayList<>();
+        expectedErrorList.add("ERRROR_FOO");
+        expectedErrorList.add("ERROR_BAR");
+        expectedErrorList.add("ANOTHER_ERROR");
+        assertEquals(expectedErrorList, JdbcAdapterProperties.getIgnoreErrorList(properties));
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
@@ -249,7 +249,7 @@ public class JdbcAdapterPropertiesTest {
     }
 
     @Test
-    public void getIgnoreErrorList() {
+    public void getIgnoreErrors() {
         Map<String, String> properties = new HashMap<>();
         properties.put("IGNORE_ERRORS", "ERrror_foo, error_bar    ,  another_error, уккщк");
         List<String> expectedErrorList = new ArrayList<>();
@@ -258,5 +258,13 @@ public class JdbcAdapterPropertiesTest {
         expectedErrorList.add("ANOTHER_ERROR");
         expectedErrorList.add("УККЩК");
         assertEquals(expectedErrorList, JdbcAdapterProperties.getIgnoreErrorList(properties));
+    }
+
+    @Test(expected = InvalidPropertyException.class)
+    public void checkIgnoreErrorsConsistency() throws AdapterException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("IGNORE_ERRORS", "ORACLE_ERROR");
+        properties.put("dialect", "postgresql");
+        JdbcAdapterProperties.checkPropertyConsistency(properties);
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
@@ -251,7 +251,7 @@ public class JdbcAdapterPropertiesTest {
     @Test
     public void getIgnoreErrorList() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("IGNORE_ERROR_LIST", "ERrror_foo, error_bar    ,  another_error, уккщк");
+        properties.put("IGNORE_ERRORS", "ERrror_foo, error_bar    ,  another_error, уккщк");
         List<String> expectedErrorList = new ArrayList<>();
         expectedErrorList.add("ERRROR_FOO");
         expectedErrorList.add("ERROR_BAR");

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterPropertiesTest.java
@@ -251,11 +251,12 @@ public class JdbcAdapterPropertiesTest {
     @Test
     public void getIgnoreErrorList() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("IGNORE_ERROR_LIST", "ERrror_foo, error_bar    ,  another_error");
+        properties.put("IGNORE_ERROR_LIST", "ERrror_foo, error_bar    ,  another_error, уккщк");
         List<String> expectedErrorList = new ArrayList<>();
         expectedErrorList.add("ERRROR_FOO");
         expectedErrorList.add("ERROR_BAR");
         expectedErrorList.add("ANOTHER_ERROR");
+        expectedErrorList.add("УККЩК");
         assertEquals(expectedErrorList, JdbcAdapterProperties.getIgnoreErrorList(properties));
     }
 }


### PR DESCRIPTION
Unqouted identifiers are supported for the postgres dialect.
An error is raised during virtual schema creation (or refresh) if postgres identifiers contain uppercase characters. Schema creation can be enforced by setting the `ignore_error_list` property to `POSTGRES_IGNORE_UPPERCASE_TABLES`.