### PR TITLE
Bugfix/83 passwords exposed for ORA connections

### DIFF
--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -308,7 +308,7 @@ public class JdbcAdapter {
 
     protected static String getCredentialsForJDBCImport(ExaMetadata exaMeta, SchemaMetadataInfo meta) {
         String credentials = "";
-        if (JdbcAdapterProperties.userSpecifiedConnection(meta.getProperties())) {
+        if (JdbcAdapterProperties.isUserSpecifiedConnection(meta.getProperties())) {
             credentials = JdbcAdapterProperties.getConnectionName(meta.getProperties());
         } else {
             credentials = getUserAndPasswordForImport(exaMeta, meta);
@@ -320,7 +320,7 @@ public class JdbcAdapter {
 
     protected static String getCredentialsForORAImport(ExaMetadata exaMeta, SchemaMetadataInfo meta) {
         String credentials = "";
-        if (!JdbcAdapterProperties.userSpecifiedConnection(meta.getProperties())) {
+        if (!JdbcAdapterProperties.isUserSpecifiedConnection(meta.getProperties())) {
             credentials = getUserAndPasswordForImport(exaMeta, meta);
         }
         return credentials;

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapter.java
@@ -259,31 +259,51 @@ public class JdbcAdapter {
 
     private static String generateExasolImportQuery(ExaMetadata exaMeta, SchemaMetadataInfo meta, String pushdownQuery) {
         String credentials = getCredentialsForEXAImport(exaMeta, meta);
-        return String.format("IMPORT FROM EXA AT '%s' %s STATEMENT '%s'",
-                JdbcAdapterProperties.getExaConnectionString(meta.getProperties()), credentials,
-                pushdownQuery.replace("'", "''"));
+        StringBuilder exasolImportQuery = new StringBuilder();
+        exasolImportQuery.append("IMPORT FROM EXA AT '");
+        exasolImportQuery.append(JdbcAdapterProperties.getExaConnectionString(meta.getProperties()));
+        exasolImportQuery.append("' ");
+        exasolImportQuery.append(credentials);
+        exasolImportQuery.append(" STATEMENT '");
+        exasolImportQuery.append( pushdownQuery.replace("'", "''"));
+        exasolImportQuery.append("'");
+        return exasolImportQuery.toString();
     }
 
     private static String generateOracleImportQuery(ExaMetadata exaMeta, SchemaMetadataInfo meta, String pushdownQuery) {
         String credentials = getCredentialsForORAImport(exaMeta, meta);
-        return String.format("IMPORT FROM ORA AT %s %s STATEMENT '%s'",
-                JdbcAdapterProperties.getOraConnectionName(meta.getProperties()), credentials,
-                pushdownQuery.replace("'", "''"));
+        StringBuilder oracleImportQuery = new StringBuilder();
+        oracleImportQuery.append("IMPORT FROM ORA AT ");
+        oracleImportQuery.append(JdbcAdapterProperties.getOraConnectionName(meta.getProperties()));
+        oracleImportQuery.append(" ");
+        oracleImportQuery.append(credentials);
+        oracleImportQuery.append(" STATEMENT '");
+        oracleImportQuery.append( pushdownQuery.replace("'", "''"));
+        oracleImportQuery.append("'");
+        return oracleImportQuery.toString();
     }
 
     private static String generateJDBCImportQuery(ExaMetadata exaMeta, SchemaMetadataInfo meta, SqlDialect dialect, String pushdownQuery) throws AdapterException {
         String credentials = getCredentialsForJDBCImport(exaMeta, meta);
 
-        String sql;
+        StringBuilder jdbcImportQuery = new StringBuilder();
         final String columnDescription = createColumnDescription(exaMeta, meta, pushdownQuery, dialect);
         if (columnDescription == null) {
-            sql = String.format("IMPORT FROM JDBC AT %s STATEMENT '%s'", credentials,
-                    pushdownQuery.replace("'", "''"));
+            jdbcImportQuery.append("IMPORT FROM JDBC AT ");
+            jdbcImportQuery.append(credentials);
+            jdbcImportQuery.append(" STATEMENT '");
+            jdbcImportQuery.append( pushdownQuery.replace("'", "''"));
+            jdbcImportQuery.append("'");
         } else {
-            sql = String.format("IMPORT INTO %s FROM JDBC AT %s STATEMENT '%s'", columnDescription, credentials,
-                    pushdownQuery.replace("'", "''"));
+            jdbcImportQuery.append("IMPORT INTO ");
+            jdbcImportQuery.append(columnDescription);
+            jdbcImportQuery.append(" FROM JDBC AT ");
+            jdbcImportQuery.append(credentials);
+            jdbcImportQuery.append(" STATEMENT '");
+            jdbcImportQuery.append( pushdownQuery.replace("'", "''"));
+            jdbcImportQuery.append("'");
         }
-        return sql;
+        return jdbcImportQuery.toString();
     }
 
     protected static String getCredentialsForJDBCImport(ExaMetadata exaMeta, SchemaMetadataInfo meta) {

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/JdbcAdapterProperties.java
@@ -86,7 +86,7 @@ public final class JdbcAdapterProperties {
         return getProperty(properties, PROP_SCHEMA_NAME);
     }
 
-    public static boolean userSpecifiedConnection(final Map<String, String> properties) {
+    public static boolean isUserSpecifiedConnection(final Map<String, String> properties) {
         final String connName = getProperty(properties, PROP_CONNECTION_NAME);
         return (connName != null && !connName.isEmpty());
     }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -31,6 +31,49 @@ import com.google.common.collect.ImmutableList;
  */
 public class ExasolSqlDialectIT extends AbstractIntegrationTest {
 
+    public static class ConnectionBuilder {
+        private String connectionName;
+        private String connectionString;
+        private String connectionUser;
+        private String connectionPassword;
+
+        public ConnectionBuilder(
+                final String connectionName,
+                final String connectionString) {
+            this.connectionName = connectionName;
+            this.connectionString = connectionString;
+            this.connectionUser = "";
+            this.connectionPassword = "";
+        }
+
+        public ConnectionBuilder user(final String user) {
+            this.connectionUser = user;
+            return this;
+        }
+
+        public ConnectionBuilder password(final String password) {
+            this.connectionPassword = password;
+            return this;
+        }
+
+        public String getCreateConnection() {
+            StringBuilder createConnection = new StringBuilder();
+            createConnection.append("CREATE CONNECTION ");
+            createConnection.append(this.connectionName);
+            createConnection.append(" TO '");
+            createConnection.append(this.connectionString);
+            createConnection.append("'");
+            if (this.connectionUser != "" && this.connectionPassword != "") {
+                createConnection.append(" USER '");
+                createConnection.append(this.connectionUser);
+                createConnection.append("' IDENTIFIED BY '");
+                createConnection.append(this.connectionPassword);
+                createConnection.append("'");
+            }
+            return createConnection.toString();
+        }
+    }
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -299,9 +342,11 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     @Test
     public void testVirtualSchemaImportFromJDBCWithConnectionName() throws SQLException, FileNotFoundException {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
-        final String createConnection = "create connection VS_JDBC_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
-                + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
-        execute(createConnection);
+        ConnectionBuilder JDBCConnection = new ConnectionBuilder(
+                "VS_JDBC_WITH_CONNNAME_CONNECTION", connectionString).
+                user(getConfig().getExasolUser()).
+                password(getConfig().getExasolPassword());
+        execute(JDBCConnection.getCreateConnection());
         createVirtualSchema("VS_JDBC_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_JDBC_WITH_CONNNAME_CONNECTION",
         "", "", "ADAPTER.JDBC_ADAPTER", "",
         false, "", "", null);
@@ -315,9 +360,11 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     @Test
     public void testVirtualSchemaImportFromEXAWithConnectionName() throws SQLException, FileNotFoundException {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
-        final String createConnection = "create connection VS_EXA_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
-                + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
-        execute(createConnection);
+        ConnectionBuilder EXAConnection = new ConnectionBuilder(
+                "VS_EXA_WITH_CONNNAME_CONNECTION", connectionString).
+                user(getConfig().getExasolUser()).
+                password(getConfig().getExasolPassword());
+        execute(EXAConnection.getCreateConnection());
         createVirtualSchema("VS_EXA_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_EXA_WITH_CONNNAME_CONNECTION",
                 "", "", "ADAPTER.JDBC_ADAPTER", "",
                 false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -132,31 +132,33 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testIdentifierCaseSensitivity() throws SQLException, FileNotFoundException {
-        ResultSet result = executeQuery("SELECT * FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
-        matchLastRow(result, 1L, 2L, 3L);
-        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
-        matchLastRow(result, 1L, 2L, 3L);
-        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
+    public void testIdentifierCaseSensitivityOnTable() throws SQLException {
+        final ResultSet result = executeQuery("SELECT * FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
         matchLastRow(result, 1L, 2L, 3L);
     }
 
     @Test
-    public void testIdentifierCaseSensitivityException1() throws SQLException, FileNotFoundException {
+    public void testIdentifierCaseSensitivityOnColumns() throws SQLException {
+        final ResultSet result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
+        matchLastRow(result, 1L, 2L, 3L);
+    }
+
+    @Test
+    public void assertUnquotedMixedCaseTableIsNotFound() throws SQLException {
         this.thrown.expect(SQLException.class);
         this.thrown.expectMessage("object VS_EXA_IT_MIXED_CASE.TABLE_MIXED_CASE not found");
         executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".Table_Mixed_Case");
     }
 
     @Test
-    public void testIdentifierCaseSensitivityException2() throws SQLException, FileNotFoundException {
+    public void assertUnquotedMixedCaseColumnIsNotFound() throws SQLException {
         this.thrown.expect(SQLException.class);
         this.thrown.expectMessage("object COLUMN1 not found");
         executeQuery("SELECT Column1, column2, COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
     }
 
     @Test
-    public void testGroupConcat() throws SQLException, FileNotFoundException {
+    public void testGroupConcat() throws SQLException {
         String query = "SELECT GROUP_CONCAT(A) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
         matchLastRow(result, "1,1,2,2,3,3");
@@ -189,7 +191,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testExtract() throws SQLException, FileNotFoundException {
+    public void testExtract() throws SQLException {
         String query = "SELECT EXTRACT(MONTH FROM C9) FROM " + VIRTUAL_SCHEMA + ".ALL_EXA_TYPES";
         ResultSet result = executeQuery(query);
         matchLastRow(result, (short) 8);
@@ -201,7 +203,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testCast() throws SQLException, FileNotFoundException {
+    public void testCast() throws SQLException {
         String query = "SELECT CAST(A AS CHAR(15)) FROM " + VIRTUAL_SCHEMA + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
         matchNextRow(result, "1              ");
@@ -271,7 +273,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     }
 
     @Test
-    public void testCase() throws SQLException, FileNotFoundException {
+    public void testCase() throws SQLException {
         String query = "SELECT CASE A WHEN 1 THEN 'YES' WHEN 2 THEN 'PERHAPS' ELSE 'NO' END FROM " + VIRTUAL_SCHEMA
                 + ".SIMPLE_VALUES";
         ResultSet result = executeQuery(query);
@@ -297,14 +299,14 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     @Test
     public void testVirtualSchemaImportFromJDBCWithConnectionName() throws SQLException, FileNotFoundException {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
-        String createConnection = "create connection VS_JDBC_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
+        final String createConnection = "create connection VS_JDBC_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
                 + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
         execute(createConnection);
         createVirtualSchema("VS_JDBC_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_JDBC_WITH_CONNNAME_CONNECTION",
         "", "", "ADAPTER.JDBC_ADAPTER", "",
         false, "", "", null);
-        String query = "SELECT 1 FROM VS_JDBC_WITH_CONNNAME.SIMPLE_VALUES";
-        ResultSet result = executeQuery(query);
+        final String query = "SELECT 1 FROM VS_JDBC_WITH_CONNNAME.SIMPLE_VALUES";
+        final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
         matchSingleRowExplain(query, "IMPORT INTO (c0 DECIMAL(1, 0)) FROM JDBC AT VS_JDBC_WITH_CONNNAME_CONNECTION STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
                 IS_LOCAL);
@@ -313,14 +315,14 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     @Test
     public void testVirtualSchemaImportFromEXAWithConnectionName() throws SQLException, FileNotFoundException {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
-        String createConnection = "create connection VS_EXA_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
+        final String createConnection = "create connection VS_EXA_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
                 + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
         execute(createConnection);
         createVirtualSchema("VS_EXA_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_EXA_WITH_CONNNAME_CONNECTION",
                 "", "", "ADAPTER.JDBC_ADAPTER", "",
                 false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
-        String query = "SELECT 1 FROM VS_EXA_WITH_CONNNAME.SIMPLE_VALUES";
-        ResultSet result = executeQuery(query);
+        final String query = "SELECT 1 FROM VS_EXA_WITH_CONNNAME.SIMPLE_VALUES";
+        final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
         matchSingleRowExplain(query, "IMPORT FROM EXA AT 'localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
                 IS_LOCAL);
@@ -332,8 +334,8 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         createVirtualSchema("VS_JDBC_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
                 false, "", "", null);
-        String query = "SELECT 1 FROM VS_JDBC_WITH_USER_PW.SIMPLE_VALUES";
-        ResultSet result = executeQuery(query);
+        final String query = "SELECT 1 FROM VS_JDBC_WITH_USER_PW.SIMPLE_VALUES";
+        final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
         matchSingleRowExplain(query, "IMPORT INTO (c0 DECIMAL(1, 0)) FROM JDBC AT 'jdbc:exa:localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
                 IS_LOCAL);
@@ -345,8 +347,8 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         createVirtualSchema("VS_EXA_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
                 false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
-        String query = "SELECT 1 FROM VS_EXA_WITH_USER_PW.SIMPLE_VALUES";
-        ResultSet result = executeQuery(query);
+        final String query = "SELECT 1 FROM VS_EXA_WITH_USER_PW.SIMPLE_VALUES";
+        final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
         matchSingleRowExplain(query, "IMPORT FROM EXA AT 'localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
                 IS_LOCAL);
@@ -360,7 +362,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
     @Ignore
     @Test
     public void testDifferentDataTypes()
-            throws SQLException, ClassNotFoundException, FileNotFoundException, AdapterException {
+            throws SQLException, FileNotFoundException, AdapterException {
         final Statement stmt = getConnection().createStatement();
         createOrReplaceSchema(stmt);
         createTables(stmt);

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -350,7 +350,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         execute(JDBCConnection.getCreateConnection());
         createVirtualSchema("VS_JDBC_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_JDBC_WITH_CONNNAME_CONNECTION",
         "", "", "ADAPTER.JDBC_ADAPTER", "",
-        false, "", "", null);
+        false, "", "", null, "");
         final String query = "SELECT 1 FROM VS_JDBC_WITH_CONNNAME.SIMPLE_VALUES";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
@@ -368,7 +368,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         execute(EXAConnection.getCreateConnection());
         createVirtualSchema("VS_EXA_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_EXA_WITH_CONNNAME_CONNECTION",
                 "", "", "ADAPTER.JDBC_ADAPTER", "",
-                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
+                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'", "");
         final String query = "SELECT 1 FROM VS_EXA_WITH_CONNNAME.SIMPLE_VALUES";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
@@ -381,7 +381,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
         createVirtualSchema("VS_JDBC_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
-                false, "", "", null);
+                false, "", "", null, "");
         final String query = "SELECT 1 FROM VS_JDBC_WITH_USER_PW.SIMPLE_VALUES";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));
@@ -394,7 +394,7 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
         createVirtualSchema("VS_EXA_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
                 getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
-                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
+                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'", "");
         final String query = "SELECT 1 FROM VS_EXA_WITH_USER_PW.SIMPLE_VALUES";
         final ResultSet result = executeQuery(query);
         matchNextRow(result, new Short("1"));

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/dialects/impl/ExasolSqlDialectIT.java
@@ -133,26 +133,26 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
 
     @Test
     public void testIdentifierCaseSensitivity() throws SQLException, FileNotFoundException {
-        ResultSet result = executeQuery("SELECT * FROM \"Table_Mixed_Case\"");
+        ResultSet result = executeQuery("SELECT * FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
         matchLastRow(result, 1L, 2L, 3L);
-        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM \"Table_Mixed_Case\"");
+        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
         matchLastRow(result, 1L, 2L, 3L);
-        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM \"Table_Mixed_Case\"");
+        result = executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
         matchLastRow(result, 1L, 2L, 3L);
     }
 
     @Test
     public void testIdentifierCaseSensitivityException1() throws SQLException, FileNotFoundException {
         this.thrown.expect(SQLException.class);
-        this.thrown.expectMessage("object TABLE_MIXED_CASE not found");
-        executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM Table_Mixed_Case");
+        this.thrown.expectMessage("object VS_EXA_IT_MIXED_CASE.TABLE_MIXED_CASE not found");
+        executeQuery("SELECT \"Column1\", \"column2\", COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".Table_Mixed_Case");
     }
 
     @Test
     public void testIdentifierCaseSensitivityException2() throws SQLException, FileNotFoundException {
         this.thrown.expect(SQLException.class);
         this.thrown.expectMessage("object COLUMN1 not found");
-        executeQuery("SELECT Column1, column2, COLUMN3 FROM \"Table_Mixed_Case\"");
+        executeQuery("SELECT Column1, column2, COLUMN3 FROM " + VIRTUAL_SCHEMA_MIXED_CASE + ".\"Table_Mixed_Case\"");
     }
 
     @Test
@@ -293,6 +293,65 @@ public class ExasolSqlDialectIT extends AbstractIntegrationTest {
         "", "", "ADAPTER.JDBC_ADAPTER", "",
         false, getConfig().debugAddress(), "", null);
     }
+
+    @Test
+    public void testVirtualSchemaImportFromJDBCWithConnectionName() throws SQLException, FileNotFoundException {
+        final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
+        String createConnection = "create connection VS_JDBC_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
+                + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
+        execute(createConnection);
+        createVirtualSchema("VS_JDBC_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_JDBC_WITH_CONNNAME_CONNECTION",
+        "", "", "ADAPTER.JDBC_ADAPTER", "",
+        false, "", "", null);
+        String query = "SELECT 1 FROM VS_JDBC_WITH_CONNNAME.SIMPLE_VALUES";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, new Short("1"));
+        matchSingleRowExplain(query, "IMPORT INTO (c0 DECIMAL(1, 0)) FROM JDBC AT VS_JDBC_WITH_CONNNAME_CONNECTION STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
+                IS_LOCAL);
+    }
+
+    @Test
+    public void testVirtualSchemaImportFromEXAWithConnectionName() throws SQLException, FileNotFoundException {
+        final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
+        String createConnection = "create connection VS_EXA_WITH_CONNNAME_CONNECTION to '" + connectionString + "' user '"
+                + getConfig().getExasolUser() +"' identified by '"+ getConfig().getExasolPassword() +"'";
+        execute(createConnection);
+        createVirtualSchema("VS_EXA_WITH_CONNNAME", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "VS_EXA_WITH_CONNNAME_CONNECTION",
+                "", "", "ADAPTER.JDBC_ADAPTER", "",
+                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
+        String query = "SELECT 1 FROM VS_EXA_WITH_CONNNAME.SIMPLE_VALUES";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, new Short("1"));
+        matchSingleRowExplain(query, "IMPORT FROM EXA AT 'localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
+                IS_LOCAL);
+    }
+
+    @Test
+    public void testVirtualSchemaImportFromJDBCWithConnectionStringUserPassword() throws SQLException, FileNotFoundException {
+        final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
+        createVirtualSchema("VS_JDBC_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
+                getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
+                false, "", "", null);
+        String query = "SELECT 1 FROM VS_JDBC_WITH_USER_PW.SIMPLE_VALUES";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, new Short("1"));
+        matchSingleRowExplain(query, "IMPORT INTO (c0 DECIMAL(1, 0)) FROM JDBC AT 'jdbc:exa:localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
+                IS_LOCAL);
+    }
+
+    @Test
+    public void testVirtualSchemaImportFromEXAWithConnectionStringUserPassword() throws SQLException, FileNotFoundException {
+        final String connectionString = "jdbc:exa:localhost:" + getPortOfConnectedDatabase();
+        createVirtualSchema("VS_EXA_WITH_USER_PW", ExasolSqlDialect.getPublicName(), "", TEST_SCHEMA, "",
+                getConfig().getExasolUser(), getConfig().getExasolPassword(), "ADAPTER.JDBC_ADAPTER", connectionString,
+                false, "", "", "IMPORT_FROM_EXA = 'true' EXA_CONNECTION_STRING = 'localhost:" + getPortOfConnectedDatabase() + "'");
+        String query = "SELECT 1 FROM VS_EXA_WITH_USER_PW.SIMPLE_VALUES";
+        ResultSet result = executeQuery(query);
+        matchNextRow(result, new Short("1"));
+        matchSingleRowExplain(query, "IMPORT FROM EXA AT 'localhost:8888' USER 'sys' IDENTIFIED BY 'exasol' STATEMENT 'SELECT 1 FROM \"NATIVE_EXA_IT\".\"SIMPLE_VALUES\"'",
+                IS_LOCAL);
+    }
+
 
     /**
      * This was replaced by integration test {@link #testDataTypeMapping()}. It can

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
@@ -26,9 +26,9 @@ public class JdbcAdapterTest {
         exaConnectionInformation = mock(ExaConnectionInformation.class);
         exaMetadata = mock(ExaMetadata.class);
 
-        when(exaConnectionInformation.getUser()).thenReturn("testUser");
-        when(exaConnectionInformation.getPassword()).thenReturn("testPassword");
-        when(exaConnectionInformation.getAddress()).thenReturn("testAddress");
+        when(exaConnectionInformation.getUser()).thenReturn("testCommUser");
+        when(exaConnectionInformation.getPassword()).thenReturn("testConnPassword");
+        when(exaConnectionInformation.getAddress()).thenReturn("testConnAddress");
         when(exaMetadata.getConnection(any())).thenReturn(exaConnectionInformation);
     }
 
@@ -37,17 +37,26 @@ public class JdbcAdapterTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_NAME", "JDBC_ORACLE");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
-        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, true);
+        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
         assertEquals("JDBC_ORACLE", credentials);
     }
 
     @Test
-    public void getCredentialsForORAorEXAImportWithConnectionNameGiven() {
+    public void getCredentialsForORAImportWithConnectionNameGiven() {
         Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_NAME", "JDBC_ORACLE");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
-        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, false);
+        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("", credentials);
+    }
+
+    @Test
+    public void getCredentialsForEXAImportWithConnectionNameGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_NAME", "JDBC_EXA");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
+        assertEquals("USER 'testCommUser' IDENTIFIED BY 'testConnPassword'", credentials);
     }
 
     @Test
@@ -57,18 +66,29 @@ public class JdbcAdapterTest {
         properties.put("USERNAME", "testUsername");
         properties.put("PASSWORD", "testPassword");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
-        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, true);
+        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
         assertEquals("'testConnectionString' USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 
     @Test
-    public void getCredentialsForORAorEXAImportWithConnectionStringUsernamePasswordGiven() {
+    public void getCredentialsForORAImportWithConnectionStringUsernamePasswordGiven() {
         Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_STRING", "testConnectionString");
         properties.put("USERNAME", "testUsername");
         properties.put("PASSWORD", "testPassword");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
-        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, false);
+        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
+        assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
+    }
+
+    @Test
+    public void getCredentialsForEXAImportWithConnectionStringUsernamePasswordGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_STRING", "testConnectionString");
+        properties.put("USERNAME", "testUsername");
+        properties.put("PASSWORD", "testPassword");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 public class JdbcAdapterTest {
     private ExaConnectionInformation exaConnectionInformation;
     private ExaMetadata exaMetadata;
+    private Map<String, String> propertiesConnectionStringUserPassword;
+    private Map<String, String> propertiesConnectionName;
 
     @Before
     public void setUp() throws ExaConnectionAccessException {
@@ -28,64 +30,54 @@ public class JdbcAdapterTest {
         when(exaConnectionInformation.getPassword()).thenReturn("testConnPassword");
         when(exaConnectionInformation.getAddress()).thenReturn("testConnAddress");
         when(exaMetadata.getConnection(any())).thenReturn(exaConnectionInformation);
+
+        propertiesConnectionStringUserPassword = new HashMap<>();
+        propertiesConnectionStringUserPassword.put("CONNECTION_STRING", "testConnectionString");
+        propertiesConnectionStringUserPassword.put("USERNAME", "testUsername");
+        propertiesConnectionStringUserPassword.put("PASSWORD", "testPassword");
+        propertiesConnectionName = new HashMap<>();
+        propertiesConnectionName.put("CONNECTION_NAME", "CONN_NAME");
+
     }
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionNameGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_NAME", "JDBC_ORACLE");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
         final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
-        assertEquals("JDBC_ORACLE", credentials);
+        assertEquals("CONN_NAME", credentials);
     }
 
     @Test
     public void getCredentialsForORAImportWithConnectionNameGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_NAME", "JDBC_ORACLE");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
         final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("", credentials);
     }
 
     @Test
     public void getCredentialsForEXAImportWithConnectionNameGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_NAME", "JDBC_EXA");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
         final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("USER 'testCommUser' IDENTIFIED BY 'testConnPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionStringUsernamePasswordGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_STRING", "testConnectionString");
-        properties.put("USERNAME", "testUsername");
-        properties.put("PASSWORD", "testPassword");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
         final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
         assertEquals("'testConnectionString' USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForORAImportWithConnectionStringUsernamePasswordGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_STRING", "testConnectionString");
-        properties.put("USERNAME", "testUsername");
-        properties.put("PASSWORD", "testPassword");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
         final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForEXAImportWithConnectionStringUsernamePasswordGiven() {
-        final Map<String, String> properties = new HashMap<>();
-        properties.put("CONNECTION_STRING", "testConnectionString");
-        properties.put("USERNAME", "testUsername");
-        properties.put("PASSWORD", "testPassword");
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
         final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
         assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
@@ -1,0 +1,74 @@
+package com.exasol.adapter.jdbc;
+
+import com.exasol.ExaConnectionAccessException;
+import com.exasol.ExaConnectionInformation;
+import com.exasol.ExaMetadata;
+import com.exasol.adapter.metadata.SchemaMetadata;
+import com.exasol.adapter.metadata.SchemaMetadataInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class JdbcAdapterTest {
+    private ExaConnectionInformation exaConnectionInformation;
+    private ExaMetadata exaMetadata;
+
+    @Before
+    public void setUp() throws ExaConnectionAccessException {
+        exaConnectionInformation = mock(ExaConnectionInformation.class);
+        exaMetadata = mock(ExaMetadata.class);
+
+        when(exaConnectionInformation.getUser()).thenReturn("testUser");
+        when(exaConnectionInformation.getPassword()).thenReturn("testPassword");
+        when(exaConnectionInformation.getAddress()).thenReturn("testAddress");
+        when(exaMetadata.getConnection(any())).thenReturn(exaConnectionInformation);
+    }
+
+    @Test
+    public void getCredentialsForJDBCImportWithConnectionNameGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_NAME", "JDBC_ORACLE");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, true);
+        assertEquals("JDBC_ORACLE", credentials);
+    }
+
+    @Test
+    public void getCredentialsForORAorEXAImportWithConnectionNameGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_NAME", "JDBC_ORACLE");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, false);
+        assertEquals("", credentials);
+    }
+
+    @Test
+    public void getCredentialsForJDBCImportWithConnectionStringUsernamePasswordGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_STRING", "testConnectionString");
+        properties.put("USERNAME", "testUsername");
+        properties.put("PASSWORD", "testPassword");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, true);
+        assertEquals("'testConnectionString' USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
+    }
+
+    @Test
+    public void getCredentialsForORAorEXAImportWithConnectionStringUsernamePasswordGiven() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("CONNECTION_STRING", "testConnectionString");
+        properties.put("USERNAME", "testUsername");
+        properties.put("PASSWORD", "testPassword");
+        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
+        final String credentials = JdbcAdapter.getCredentialsForImport(exaMetadata, schemaMetadataInfo, false);
+        assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
+    }
+}

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
@@ -3,11 +3,9 @@ package com.exasol.adapter.jdbc;
 import com.exasol.ExaConnectionAccessException;
 import com.exasol.ExaConnectionInformation;
 import com.exasol.ExaMetadata;
-import com.exasol.adapter.metadata.SchemaMetadata;
 import com.exasol.adapter.metadata.SchemaMetadataInfo;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,7 +32,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionNameGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_NAME", "JDBC_ORACLE");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
         final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
@@ -43,7 +41,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForORAImportWithConnectionNameGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_NAME", "JDBC_ORACLE");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
         final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
@@ -52,7 +50,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForEXAImportWithConnectionNameGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_NAME", "JDBC_EXA");
         final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", properties);
         final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
@@ -61,7 +59,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionStringUsernamePasswordGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_STRING", "testConnectionString");
         properties.put("USERNAME", "testUsername");
         properties.put("PASSWORD", "testPassword");
@@ -72,7 +70,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForORAImportWithConnectionStringUsernamePasswordGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_STRING", "testConnectionString");
         properties.put("USERNAME", "testUsername");
         properties.put("PASSWORD", "testPassword");
@@ -83,7 +81,7 @@ public class JdbcAdapterTest {
 
     @Test
     public void getCredentialsForEXAImportWithConnectionStringUsernamePasswordGiven() {
-        Map<String, String> properties = new HashMap<>();
+        final Map<String, String> properties = new HashMap<>();
         properties.put("CONNECTION_STRING", "testConnectionString");
         properties.put("USERNAME", "testUsername");
         properties.put("PASSWORD", "testPassword");

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/JdbcAdapterTest.java
@@ -18,8 +18,9 @@ import static org.mockito.Mockito.when;
 public class JdbcAdapterTest {
     private ExaConnectionInformation exaConnectionInformation;
     private ExaMetadata exaMetadata;
-    private Map<String, String> propertiesConnectionStringUserPassword;
-    private Map<String, String> propertiesConnectionName;
+    private SchemaMetadataInfo schemaMetadataInfoConnectionStringUserPassword;
+    private SchemaMetadataInfo schemaMetadataInfoConnectionName;
+
 
     @Before
     public void setUp() throws ExaConnectionAccessException {
@@ -31,54 +32,50 @@ public class JdbcAdapterTest {
         when(exaConnectionInformation.getAddress()).thenReturn("testConnAddress");
         when(exaMetadata.getConnection(any())).thenReturn(exaConnectionInformation);
 
-        propertiesConnectionStringUserPassword = new HashMap<>();
+        Map<String, String> propertiesConnectionStringUserPassword = new HashMap<>();
         propertiesConnectionStringUserPassword.put("CONNECTION_STRING", "testConnectionString");
         propertiesConnectionStringUserPassword.put("USERNAME", "testUsername");
         propertiesConnectionStringUserPassword.put("PASSWORD", "testPassword");
-        propertiesConnectionName = new HashMap<>();
-        propertiesConnectionName.put("CONNECTION_NAME", "CONN_NAME");
+        schemaMetadataInfoConnectionStringUserPassword = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
 
+        Map<String, String> propertiesConnectionName = new HashMap<>();
+        propertiesConnectionName.put("CONNECTION_NAME", "CONN_NAME");
+        schemaMetadataInfoConnectionName = new SchemaMetadataInfo("", "", propertiesConnectionName);
     }
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionNameGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
-        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfoConnectionName);
         assertEquals("CONN_NAME", credentials);
     }
 
     @Test
     public void getCredentialsForORAImportWithConnectionNameGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
-        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfoConnectionName);
         assertEquals("", credentials);
     }
 
     @Test
     public void getCredentialsForEXAImportWithConnectionNameGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionName);
-        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfoConnectionName);
         assertEquals("USER 'testCommUser' IDENTIFIED BY 'testConnPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForJDBCImportWithConnectionStringUsernamePasswordGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
-        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForJDBCImport(exaMetadata, schemaMetadataInfoConnectionStringUserPassword);
         assertEquals("'testConnectionString' USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForORAImportWithConnectionStringUsernamePasswordGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
-        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForORAImport(exaMetadata, schemaMetadataInfoConnectionStringUserPassword);
         assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 
     @Test
     public void getCredentialsForEXAImportWithConnectionStringUsernamePasswordGiven() {
-        final SchemaMetadataInfo schemaMetadataInfo = new SchemaMetadataInfo("", "", propertiesConnectionStringUserPassword);
-        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfo);
+        final String credentials = JdbcAdapter.getCredentialsForEXAImport(exaMetadata, schemaMetadataInfoConnectionStringUserPassword);
         assertEquals("USER 'testUsername' IDENTIFIED BY 'testPassword'", credentials);
     }
 }


### PR DESCRIPTION
Fix for #83.
This only covers ORA connections, the fix for EXA needs to be discussed (see #94).
This fix introduces a small change in behavior:
* before this fix: To connect to Oracle the user/password from the provided JDBC connection was used. The user/password in the Oracle connection were ignored.
* with this fix: The user/password from the Oracle connection is used. If this connection does not have user/password you have to specify the properties `USERNAME`and `PASSWORD`.
