### PR TITLE
Map SQL Server Clob (ntext, text, clob) to 2 mb varchar

### DIFF
--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/dialects/impl/SqlServerSqlDialect.java
@@ -22,6 +22,7 @@ public class SqlServerSqlDialect extends AbstractSqlDialect {
     // Tested JDBC drivers: jtds-1.3.1 (https://sourceforge.net/projects/jtds/)
     public final static int maxSqlServerVarcharSize = 8000;
     public final static int maxSqlServerNVarcharSize = 4000;
+    public final static int maxSqlServerClob = 2000000;
     private static final String NAME = "SQLSERVER";
 
     public SqlServerSqlDialect(final SqlDialectContext context) {
@@ -89,6 +90,7 @@ public class SqlServerSqlDialect extends AbstractSqlDialect {
                 colType = DataType.createDouble();
             }
             break;
+            
         case Types.OTHER:
             // TODO
             colType = DataType.createVarChar(SqlServerSqlDialect.maxSqlServerVarcharSize, DataType.ExaCharset.UTF8);
@@ -97,7 +99,7 @@ public class SqlServerSqlDialect extends AbstractSqlDialect {
             colType = DataType.createVarChar(SqlServerSqlDialect.maxSqlServerVarcharSize, DataType.ExaCharset.UTF8);
             break;
         case Types.CLOB: // xml type in SQL Server
-            colType = DataType.createVarChar(SqlServerSqlDialect.maxSqlServerNVarcharSize, DataType.ExaCharset.UTF8);
+            colType = DataType.createVarChar(SqlServerSqlDialect.maxSqlServerClob, DataType.ExaCharset.UTF8);
             break;
         case Types.BLOB:
             if (columnTypeName.equalsIgnoreCase("hierarchyid")) {


### PR DESCRIPTION
see community issue [https://www.exasol.com/portal/questions/46760256/sql-server-ntext-converted-to-varchar4000-in-virtual-schema](https://www.exasol.com/portal/questions/46760256/sql-server-ntext-converted-to-varchar4000-in-virtual-schema)