### PR TITLE
#175 fixed conversion of empty list to optional

### DIFF
--- a/doc/dialects/athena.md
+++ b/doc/dialects/athena.md
@@ -43,7 +43,7 @@ You install the adapter script via the special SQL command `CREATE JAVA ADAPTER 
 ```sql
 CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS
     %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-    %jar /buckets/bucketfs1/jdbc/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+    %jar /buckets/bucketfs1/jdbc/virtualschema-jdbc-adapter-dist-1.16.2.jar;
     %jar /buckets/bucketfs1/jdbc/AthenaJDBC42-<JDBC driver version>.jar;
 /
 ```

--- a/doc/dialects/db2.md
+++ b/doc/dialects/db2.md
@@ -46,7 +46,7 @@ CREATE or replace JAVA ADAPTER SCRIPT adapter.jdbc_adapter AS
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   // DB2 Driver files
   %jar /buckets/bucketfs1/bucket1/db2jcc4.jar;

--- a/doc/dialects/exasol.md
+++ b/doc/dialects/exasol.md
@@ -17,7 +17,7 @@ After uploading the adapter jar, the adapter script can be created as follows:
 CREATE SCHEMA adapter;
 CREATE JAVA ADAPTER SCRIPT adapter.jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 /
 ```
 

--- a/doc/dialects/hive.md
+++ b/doc/dialects/hive.md
@@ -23,7 +23,7 @@ CREATE SCHEMA adapter;
 CREATE  JAVA  ADAPTER SCRIPT jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
 
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   %jar /buckets/bucketfs1/bucket1/HiveJDBC41.jar;
 /

--- a/doc/dialects/impala.md
+++ b/doc/dialects/impala.md
@@ -22,7 +22,7 @@ CREATE SCHEMA adapter;
 CREATE  JAVA  ADAPTER SCRIPT jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
 
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   %jar /buckets/bucketfs1/bucket1/hive_metastore.jar;
   %jar /buckets/bucketfs1/bucket1/hive_service.jar;

--- a/doc/dialects/oracle.md
+++ b/doc/dialects/oracle.md
@@ -32,7 +32,7 @@ CREATE JAVA ADAPTER SCRIPT adapter.jdbc_oracle AS
 
   // You need to replace `your-bucket-fs` and `your-bucket` to match the actual location
   // of the adapter jar.
-  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   // Add the oracle jdbc driver to the classpath
   %jar /buckets/bucketfs1/bucket1/ojdbc7-12.1.0.2.jar

--- a/doc/dialects/postgresql.md
+++ b/doc/dialects/postgresql.md
@@ -15,7 +15,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here (e.g. MySQL or Hive)
   %jar /buckets/bucketfs1/bucket1/postgresql-42.0.0.jar;

--- a/doc/dialects/redshift.md
+++ b/doc/dialects/redshift.md
@@ -45,7 +45,7 @@ You install the adapter script via the special SQL command `CREATE JAVA ADAPTER 
 ```sql
 CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS
     %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-    %jar /buckets/bucketfs1/jdbc/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+    %jar /buckets/bucketfs1/jdbc/virtualschema-jdbc-adapter-dist-1.16.2.jar;
     %jar /buckets/bucketfs1/jdbc/RedshiftJDBC42-<JDBC driver version>.jar;
 /
 ```

--- a/doc/dialects/sql_server.md
+++ b/doc/dialects/sql_server.md
@@ -17,7 +17,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.sql_server_jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here 
   %jar /buckets/bucketfs1/bucket1/jtds.jar;

--- a/doc/dialects/sybase.md
+++ b/doc/dialects/sybase.md
@@ -18,7 +18,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
   AS
 
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-  %jar /buckets/bucketfs1/virtualschema/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/virtualschema/virtualschema-jdbc-adapter-dist-1.16.2.jar;
   %jar /buckets/bucketfs1/virtualschema/jtds-1.3.1.jar;
 /
 ```

--- a/doc/dialects/teradata.md
+++ b/doc/dialects/teradata.md
@@ -22,7 +22,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here (e.g. MySQL or Hive)
   %jar /buckets/bucketfs1/bucket1/terajdbc4.jar;

--- a/doc/user-guide/deploying_the_virtual_schema_adapter.md
+++ b/doc/user-guide/deploying_the_virtual_schema_adapter.md
@@ -23,7 +23,7 @@ cd virtual-schemas/jdbc-adapter/
 mvn clean -DskipTests package
 ```
 
-The resulting fat JAR is stored in `virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.16.1.jar`.
+The resulting fat JAR is stored in `virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.16.2.jar`.
 
 ## Uploading the Adapter JAR Archive
 
@@ -42,8 +42,8 @@ Following steps are required to upload a file to a bucket:
 1. Now upload the file into this bucket, e.g. using curl (adapt the hostname, BucketFS port, bucket name and bucket write password).
 
 ```bash
-curl -X PUT -T virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.16.1.jar \
- http://w:write-password@your.exasol.host.com:2580/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar
+curl -X PUT -T virtualschema-jdbc-adapter-dist/target/virtualschema-jdbc-adapter-dist-1.16.2.jar \
+ http://w:write-password@your.exasol.host.com:2580/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar
 ```
 
 See chapter 3.6.4. "The synchronous cluster file system BucketFS" in the EXASolution User Manual for more details about BucketFS.
@@ -75,7 +75,7 @@ CREATE JAVA ADAPTER SCRIPT adapter.jdbc_adapter AS
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   // You have to add all files of the data source jdbc driver here (e.g. Hive JDBC driver files)
   %jar /buckets/your-bucket-fs/your-bucket/name-of-data-source-jdbc-driver.jar;

--- a/doc/user-guide/dialects/db2.md
+++ b/doc/user-guide/dialects/db2.md
@@ -46,7 +46,7 @@ CREATE or replace JAVA ADAPTER SCRIPT adapter.jdbc_adapter AS
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   // DB2 Driver files
   %jar /buckets/bucketfs1/bucket1/db2jcc4.jar;

--- a/doc/user-guide/dialects/exasol.md
+++ b/doc/user-guide/dialects/exasol.md
@@ -17,7 +17,7 @@ After uploading the adapter jar, the adapter script can be created as follows:
 CREATE SCHEMA adapter;
 CREATE JAVA ADAPTER SCRIPT adapter.jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 /
 ```
 

--- a/doc/user-guide/dialects/hive.md
+++ b/doc/user-guide/dialects/hive.md
@@ -23,7 +23,7 @@ CREATE SCHEMA adapter;
 CREATE  JAVA  ADAPTER SCRIPT jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
 
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   %jar /buckets/bucketfs1/bucket1/HiveJDBC41.jar;
 /

--- a/doc/user-guide/dialects/impala.md
+++ b/doc/user-guide/dialects/impala.md
@@ -22,7 +22,7 @@ CREATE SCHEMA adapter;
 CREATE  JAVA  ADAPTER SCRIPT jdbc_adapter AS
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
 
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   %jar /buckets/bucketfs1/bucket1/hive_metastore.jar;
   %jar /buckets/bucketfs1/bucket1/hive_service.jar;

--- a/doc/user-guide/dialects/oracle.md
+++ b/doc/user-guide/dialects/oracle.md
@@ -32,7 +32,7 @@ CREATE JAVA ADAPTER SCRIPT adapter.jdbc_oracle AS
 
   // You need to replace `your-bucket-fs` and `your-bucket` to match the actual location
   // of the adapter jar.
-  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/your-bucket-fs/your-bucket/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 
   // Add the oracle jdbc driver to the classpath
   %jar /buckets/bucketfs1/bucket1/ojdbc7-12.1.0.2.jar

--- a/doc/user-guide/dialects/postgresql.md
+++ b/doc/user-guide/dialects/postgresql.md
@@ -15,7 +15,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here (e.g. MySQL or Hive)
   %jar /buckets/bucketfs1/bucket1/postgresql-42.0.0.jar;

--- a/doc/user-guide/dialects/redshift.md
+++ b/doc/user-guide/dialects/redshift.md
@@ -21,7 +21,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here (e.g. MySQL or Hive)
 

--- a/doc/user-guide/dialects/sql_server.md
+++ b/doc/user-guide/dialects/sql_server.md
@@ -17,7 +17,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.sql_server_jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here 
   %jar /buckets/bucketfs1/bucket1/jtds.jar;

--- a/doc/user-guide/dialects/sybase.md
+++ b/doc/user-guide/dialects/sybase.md
@@ -18,7 +18,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
   AS
 
   %scriptclass com.exasol.adapter.jdbc.JdbcAdapter;
-  %jar /buckets/bucketfs1/virtualschema/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/virtualschema/virtualschema-jdbc-adapter-dist-1.16.2.jar;
   %jar /buckets/bucketfs1/virtualschema/jtds-1.3.1.jar;
 /
 ```

--- a/doc/user-guide/dialects/teradata.md
+++ b/doc/user-guide/dialects/teradata.md
@@ -22,7 +22,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT adapter.jdbc_adapter
 
   // This will add the adapter jar to the classpath so that it can be used inside the adapter script
   // Replace the names of the bucketfs and the bucket with the ones you used.
-  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar;
+  %jar /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar;
 									 
   // You have to add all files of the data source jdbc driver here (e.g. MySQL or Hive)
   %jar /buckets/bucketfs1/bucket1/terajdbc4.jar;

--- a/jdbc-adapter/integration-test-data/integration-test-db2.yaml
+++ b/jdbc-adapter/integration-test-data/integration-test-db2.yaml
@@ -5,7 +5,7 @@ general:
   debugAddress:    '192.168.0.12:3000'  # Address which will be defined as DEBUG_ADDRESS in the virtual schemas
   bucketFsUrl:  http://exasol-host:2580/bucket1
   bucketFsPassword: bucket1
-  jdbcAdapterPath:  /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar
+  jdbcAdapterPath:  /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar
 
 exasol:
   runIntegrationTests: true

--- a/jdbc-adapter/integration-test-data/integration-test-sample.yaml
+++ b/jdbc-adapter/integration-test-data/integration-test-sample.yaml
@@ -5,7 +5,7 @@ general:
   debugAddress:    '192.168.0.12:3000'  # Address which will be defined as DEBUG_ADDRESS in the virtual schemas
   bucketFsUrl:  http://exasol-host:2580/bucket1
   bucketFsPassword: bucket1
-  jdbcAdapterPath:  /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.1.jar
+  jdbcAdapterPath:  /buckets/bucketfs1/bucket1/virtualschema-jdbc-adapter-dist-1.16.2.jar
 
 exasol:
   runIntegrationTests: true

--- a/jdbc-adapter/integration-test-data/integration-test-travis.yaml
+++ b/jdbc-adapter/integration-test-data/integration-test-travis.yaml
@@ -4,7 +4,7 @@ general:
   debug:                   false
   debugAddress:            ''
   bucketFsUrl:             http://127.0.0.1:6594/default
-  jdbcAdapterPath:         /buckets/bfsdefault/default/virtualschema-jdbc-adapter-dist-1.16.1.jar
+  jdbcAdapterPath:         /buckets/bfsdefault/default/virtualschema-jdbc-adapter-dist-1.16.2.jar
   additionalJDBCDriverDir: /vagrant/drivers/
 
 exasol:

--- a/jdbc-adapter/local/integration-test-config.yaml
+++ b/jdbc-adapter/local/integration-test-config.yaml
@@ -5,7 +5,7 @@ general:
   debugAddress:    '10.44.1.228:3000'  # Address which will be defined as DEBUG_ADDRESS in the virtual schemas
   bucketFsUrl:      http://localhost:2580/jars
   bucketFsPassword: public
-  jdbcAdapterPath:  /buckets/bfsdefault/jars/virtualschema-jdbc-adapter-dist-1.16.1.jar
+  jdbcAdapterPath:  /buckets/bfsdefault/jars/virtualschema-jdbc-adapter-dist-1.16.2.jar
 
 exasol:
   runIntegrationTests: true

--- a/jdbc-adapter/pom.xml
+++ b/jdbc-adapter/pom.xml
@@ -10,7 +10,7 @@
         <module>virtualschema-jdbc-adapter-dist</module>
     </modules>
     <properties>
-        <product.version>1.16.1</product.version>
+        <product.version>1.16.2</product.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReader.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReader.java
@@ -197,7 +197,7 @@ public class BaseRemoteMetadataReader extends AbstractMetadataReader implements 
     }
 
     protected Optional<List<String>> convertToOptional(List<String> selectedTables) {
-        if (selectedTables.size() > 0) {
+        if ((selectedTables != null) && !selectedTables.isEmpty()) {
             return Optional.of(selectedTables);
         } else {
             return Optional.empty();

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReader.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/main/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReader.java
@@ -189,10 +189,18 @@ public class BaseRemoteMetadataReader extends AbstractMetadataReader implements 
             final DatabaseMetaData remoteMetadata = this.connection.getMetaData();
             final String adapterNotes = SchemaAdapterNotesJsonConverter.getInstance()
                     .convertToJson(getSchemaAdapterNotes());
-            final List<TableMetadata> tables = extractTableMetadata(remoteMetadata, Optional.of(selectedTables));
+            final List<TableMetadata> tables = extractTableMetadata(remoteMetadata, convertToOptional(selectedTables));
             return new SchemaMetadata(adapterNotes, tables);
         } catch (final SQLException exception) {
             throw new RemoteMetadataReaderException("Unable to read remote schema metadata.", exception);
+        }
+    }
+
+    protected Optional<List<String>> convertToOptional(List<String> selectedTables) {
+        if (selectedTables.size() > 0) {
+            return Optional.of(selectedTables);
+        } else {
+            return Optional.empty();
         }
     }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReaderTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReaderTest.java
@@ -250,4 +250,15 @@ class BaseRemoteMetadataReaderTest {
         assertThat(new BaseRemoteMetadataReader(null, AdapterProperties.emptyProperties()).getSupportedTableTypes(),
                 containsInAnyOrder("TABLE", "VIEW", "SYSTEM TABLE"));
     }
+
+    @Test
+    void testConvertToOptional() {
+        final BaseRemoteMetadataReader reader = new BaseRemoteMetadataReader(null, AdapterProperties.emptyProperties());
+        assertAll(
+                () -> assertThat(reader.convertToOptional(Collections.emptyList()),
+                        equalTo(Optional.empty())),
+                () -> assertThat(reader.convertToOptional(Arrays.asList("T1")),
+                        equalTo(Optional.of(Arrays.asList("T1"))))
+        );
+    }
 }

--- a/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReaderTest.java
+++ b/jdbc-adapter/virtualschema-jdbc-adapter/src/test/java/com/exasol/adapter/jdbc/BaseRemoteMetadataReaderTest.java
@@ -257,6 +257,8 @@ class BaseRemoteMetadataReaderTest {
         assertAll(
                 () -> assertThat(reader.convertToOptional(Collections.emptyList()),
                         equalTo(Optional.empty())),
+                () -> assertThat(reader.convertToOptional(null),
+                        equalTo(Optional.empty())),
                 () -> assertThat(reader.convertToOptional(Arrays.asList("T1")),
                         equalTo(Optional.of(Arrays.asList("T1"))))
         );


### PR DESCRIPTION
Table filtering uses Optional and expects empty if no tables are given in the filter (see `BaseTableMetadataReader.isTableSelected()`). However empty lists were not converted to `Optional.empty`.
closes #175 
