### PR TITLE
fix for "WHERE false" syntax issue in saphana dialect

### DIFF
--- a/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlDialect.java
+++ b/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlDialect.java
@@ -1,11 +1,14 @@
 package com.exasol.adapter.dialects.saphana;
 
-import static com.exasol.adapter.AdapterProperties.*;
+import static com.exasol.adapter.AdapterProperties.CATALOG_NAME_PROPERTY;
+import static com.exasol.adapter.AdapterProperties.SCHEMA_NAME_PROPERTY;
 import static com.exasol.adapter.capabilities.AggregateFunctionCapability.*;
 import static com.exasol.adapter.capabilities.LiteralCapability.*;
 import static com.exasol.adapter.capabilities.MainCapability.*;
 import static com.exasol.adapter.capabilities.PredicateCapability.*;
 import static com.exasol.adapter.capabilities.ScalarFunctionCapability.*;
+import static com.exasol.adapter.capabilities.ScalarFunctionCapability.ST_INTERSECTION;
+import static com.exasol.adapter.capabilities.ScalarFunctionCapability.ST_UNION;
 
 import java.sql.SQLException;
 import java.util.*;
@@ -15,7 +18,6 @@ import com.exasol.adapter.capabilities.Capabilities;
 import com.exasol.adapter.dialects.*;
 import com.exasol.adapter.jdbc.*;
 import com.exasol.adapter.sql.ScalarFunction;
-import com.exasol.adapter.sql.SqlNodeVisitor;
 
 /**
  * This class implements the SAP HANA SQL dialect.
@@ -107,8 +109,9 @@ public class SapHanaSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
+    // http://sap.optimieren.de/hana/hana/html/_bsql_introduction.html
     public String applyQuote(final String identifier) {
-        return "\"" + identifier + "\"";
+        return super.quoteIdentifierWithDoubleQuotes(identifier);
     }
 
     @Override
@@ -117,21 +120,23 @@ public class SapHanaSqlDialect extends AbstractSqlDialect {
     }
 
     @Override
+    // https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/LATEST/en-US/209f5020751910148fd8fe88aa4d79d9.html
+    public String getStringLiteral(final String value) {
+        return super.quoteLiteralStringWithSingleQuote(value);
+    }
+
+    @Override
     protected RemoteMetadataReader createRemoteMetadataReader() {
         try {
             return new SapHanaMetadataReader(this.connectionFactory.getConnection(), this.properties);
         } catch (final SQLException exception) {
-            throw new RemoteMetadataReaderException("Unable to create HANA remote metadata reader.", exception);
+            throw new RemoteMetadataReaderException(
+                    "Unable to create HANA remote metadata reader. Caused by: " + exception.getMessage(), exception);
         }
     }
 
     @Override
     protected QueryRewriter createQueryRewriter() {
         return new BaseQueryRewriter(this, createRemoteMetadataReader(), this.connectionFactory);
-    }
-    
-    @Override
-    public SqlNodeVisitor<String> getSqlGenerationVisitor(final SqlGenerationContext context) {
-        return new SapHanaSqlGenerationVisitor(this, context);
     }
 }

--- a/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlDialect.java
+++ b/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlDialect.java
@@ -139,4 +139,8 @@ public class SapHanaSqlDialect extends AbstractSqlDialect {
     protected QueryRewriter createQueryRewriter() {
         return new BaseQueryRewriter(this, createRemoteMetadataReader(), this.connectionFactory);
     }
+    @Override
+    public SqlNodeVisitor<String> getSqlGenerationVisitor(final SqlGenerationContext context) {
+        return new SapHanaSqlGenerationVisitor(this, context);
+    }
 }

--- a/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlGenerationVisitor.java
+++ b/src/main/java/com/exasol/adapter/dialects/saphana/SapHanaSqlGenerationVisitor.java
@@ -1,0 +1,32 @@
+package com.exasol.adapter.dialects.saphana;
+
+import com.exasol.adapter.dialects.*;
+import com.exasol.adapter.sql.SqlLiteralBool;
+
+/**
+ * This class generates SQL queries for the {@link DB2SqlDialect}.
+ */
+public class SapHanaSqlGenerationVisitor extends SqlGenerationVisitor {
+    /**
+     * Create a new instance of the {@link SapHanaSqlGenerationVisitor}.
+     *
+     * @param dialect {@link SapHanaSqlDialect} SQL dialect
+     * @param context SQL generation context
+     */
+    public SapHanaSqlGenerationVisitor(final SqlDialect dialect, final SqlGenerationContext context) {
+        super(dialect, context);
+    }
+
+    @Override
+    public String visit(final SqlLiteralBool literal) {
+        if (literal.getValue())
+
+        {
+            return "1=1";
+        } else
+
+        {
+            return "1=0";
+        }
+    }
+}


### PR DESCRIPTION
As shown in EXA-31110 the standard way of handling Boolean expr. led to an error in HANA because "WHERE false" is not valid syntax there.

This addition introduces a very barebone SapHanaSqlGenerationVisitor which will not ( like the standard one ) place the value for SQLConstant True or False but override this behavior with "1=0" (false) or "1=1" (true) which should be understood by any database , including HANA.

Had to test with an older v-schema version and only did positive-testing for now - should work as desired.

Closes #414.