### PR TITLE
* #427: Excluded transitive `org.apache.httpcomponents:httpclient` de…

### DIFF
--- a/doc/changes/changes_4.0.5.md
+++ b/doc/changes/changes_4.0.5.md
@@ -2,7 +2,7 @@
 
 Code name: 
 
-## Bugs
+## Bug Fixes
 
 * #427: Excluded transitive `org.apache.httpcomponents:httpclient` dependency to avoid CVE-2020-13956.
 

--- a/doc/changes/changes_4.0.5.md
+++ b/doc/changes/changes_4.0.5.md
@@ -2,6 +2,10 @@
 
 Code name: 
 
+## Bugs
+
+* #427: Excluded transitive `org.apache.httpcomponents:httpclient` dependency to avoid CVE-2020-13956.
+
 ## Documentation
 
 * #408: Removed PostgreSQL dialect documentation as it has been migrated to https://github.com/exasol/postgresql-virtual-schema.
@@ -16,6 +20,7 @@ Code name:
 
 ## Dependency updates
 
-* Removed org.postgresql:postgresql:42.2.18
-* Removed org.testcontainers:postgresql:1.15.0
 * Updated `com.exasol:virtual-schema-common-jdbc:7.0.0` to `8.0.0`
+* Removed `org.postgresql:postgresql:42.2.18`
+* Removed `org.testcontainers:postgresql:1.15.0`
+* Removed `org.apache.httpcomponents:httpclient`

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,10 @@
             <!--Excluding transient dependencies with vulnerabilities-->
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
@@ -173,6 +177,12 @@
             <artifactId>libthrift</artifactId>
             <version>0.13.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Overrides Junit 4.12 which is used in test containers but contains a security issue:
         https://ossindex.sonatype.org/vuln/7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1 -->
@@ -189,6 +199,10 @@
             <scope>test</scope>
             <!--Excluding transient dependencies with vulnerabilities-->
             <exclusions>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>*</artifactId>
@@ -321,7 +335,7 @@
                     <descriptors>
                         <descriptor>assembly/all-dependencies.xml</descriptor>
                     </descriptors>
-                    <finalName>virtual-schema-dist-${vscjdbc.version}-bundle-${version}</finalName>
+                    <finalName>virtual-schema-dist-${vscjdbc.version}-bundle-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                 </configuration>
                 <executions>
@@ -356,6 +370,20 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.8.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>display-plugin-updates</goal>
+                            <goal>display-dependency-updates</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
                 <version>3.1.0</version>
@@ -364,27 +392,6 @@
                         <phase>package</phase>
                         <goals>
                             <goal>audit</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <excludeVulnerabilityIds>
-                        <!-- Ignores CVE-2020-15250, because we use Java 11 and junit 4.13.1 which contains a fix:
-                        https://ossindex.sonatype.org/vuln/7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1 -->
-                        <exclude>7ea56ad4-8a8b-4e51-8ed9-5aad83d8efb1</exclude>
-                    </excludeVulnerabilityIds>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>versions-maven-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>display-plugin-updates</goal>
-                            <goal>display-dependency-updates</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -427,5 +434,33 @@
                 </configuration>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.9.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>


### PR DESCRIPTION
…pendency to avoid CVE-2020-13956, removed warnings from pom file

Closes #427